### PR TITLE
Fix fsspec STAC_IO usage.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 click==7.1.2
 pystac[validation]==0.5.*
 fsspec==0.8.0
+requests==2.24.0
+aiohttp==3.6.2

--- a/stactools/__init__.py
+++ b/stactools/__init__.py
@@ -4,14 +4,14 @@ import fsspec
 
 # Use fsspec to handle IO
 def fsspec_read_method(uri):
-    with fsspec.open(uri) as f:
+    with fsspec.open(uri, mode='r') as f:
         return f.read()
 
 
 def fsspec_write_method(uri, txt):
-    with fsspec.open(uri, 'w') as f:
+    with fsspec.open(uri, mode='w') as f:
         return f.write(txt)
 
 
 pystac.STAC_IO.read_text_method = fsspec_read_method
-pystac.STAC_IO.read_text_method = fsspec_write_method
+pystac.STAC_IO.write_text_method = fsspec_write_method

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,23 @@
+import os
+import unittest
+from tempfile import TemporaryDirectory
+
+import pystac
+
+
+class IOTest(unittest.TestCase):
+    def test_fsspec_io(self):
+        with TemporaryDirectory() as tmp_dir:
+            catalog_url = (
+                'https://raw.githubusercontent.com/stac-utils/pystac/v0.5.2/tests/data-files/'
+                'catalogs/test-case-1/catalog.json')
+
+            cat = pystac.read_file(catalog_url)
+            col = cat.get_child('country-1')
+            self.assertEqual(len(list(col.get_children())), 2)
+
+            cat.normalize_and_save(tmp_dir, pystac.CatalogType.SELF_CONTAINED)
+
+            cat2 = pystac.read_file(os.path.join(tmp_dir, 'catalog.json'))
+            col2 = cat2.get_child('country-1')
+            self.assertEqual(len(list(col2.get_children())), 2)


### PR DESCRIPTION
This fixes the fsspec usage for STAC_IO by fixing a typo, installing the required libraries for HTTPS reads, and writing a unit test to check that IO works.