### PR TITLE
Use different version files for each subpackage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## stactools
-![Build Status](https://github.com/stac-utils/stactools/workflows/CI/badge.svg?branch=develop)
+![Build Status](https://github.com/stac-utils/stactools/workflows/CI/badge.svg)
 [![Documentation](https://readthedocs.org/projects/stactools/badge/?version=latest)](https://stactools.readthedocs.io/en/latest/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 

--- a/stactools_browse/setup.py
+++ b/stactools_browse/setup.py
@@ -9,9 +9,9 @@ description = ("Subpackage for running stac-browser against local "
                "STACs through docker.")
 
 __version__ = load_source(
-    'stactools.core.version',
-    os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-                 'stactools_core/stactools/core/version.py')).__version__
+    'stactools.browse.version',
+    os.path.join(os.path.dirname(__file__),
+                 'stactools/browse/version.py')).__version__
 
 from os.path import (basename, splitext)
 

--- a/stactools_browse/stactools/browse/version.py
+++ b/stactools_browse/stactools/browse/version.py
@@ -1,0 +1,2 @@
+__version__ = '0.0.5'
+"""Library version"""

--- a/stactools_cli/setup.py
+++ b/stactools_cli/setup.py
@@ -9,9 +9,9 @@ description = ("Subpackage containing the cli of stactools, "
                "a command line tool and Python library for working with STAC.")
 
 __version__ = load_source(
-    'stactools.core.version',
-    os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-                 'stactools_core/stactools/core/version.py')).__version__
+    'stactools.cli.version',
+    os.path.join(os.path.dirname(__file__),
+                 'stactools/cli/version.py')).__version__
 
 from os.path import (basename, splitext)
 

--- a/stactools_cli/stactools/cli/version.py
+++ b/stactools_cli/stactools/cli/version.py
@@ -1,0 +1,2 @@
+__version__ = '0.0.5'
+"""Library version"""

--- a/stactools_landsat/setup.py
+++ b/stactools_landsat/setup.py
@@ -9,9 +9,9 @@ description = ("Subpackage for working with landsat data of stactools, "
                "a command line tool and Python library for working with STAC.")
 
 __version__ = load_source(
-    'stactools.core.version',
-    os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-                 'stactools_core/stactools/core/version.py')).__version__
+    'stactools.landsat.version',
+    os.path.join(os.path.dirname(__file__),
+                 'stactools/landsat/version.py')).__version__
 
 from os.path import (basename, splitext)
 

--- a/stactools_landsat/stactools/landsat/version.py
+++ b/stactools_landsat/stactools/landsat/version.py
@@ -1,0 +1,2 @@
+__version__ = '0.0.5'
+"""Library version"""

--- a/stactools_planet/setup.py
+++ b/stactools_planet/setup.py
@@ -9,9 +9,9 @@ description = ("Subpackage for working with planet data in stactools, "
                "a command line tool and Python library for working with STAC.")
 
 __version__ = load_source(
-    'stactools.core.version',
-    os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-                 'stactools_core/stactools/core/version.py')).__version__
+    'stactools.planet.version',
+    os.path.join(os.path.dirname(__file__),
+                 'stactools/planet/version.py')).__version__
 
 from os.path import (basename, splitext)
 

--- a/stactools_planet/stactools/planet/version.py
+++ b/stactools_planet/stactools/planet/version.py
@@ -1,0 +1,2 @@
+__version__ = '0.0.5'
+"""Library version"""


### PR DESCRIPTION
The way it was configured before this change broke the docs build and didn't allow the command `pip install ./stactools_cli/ to work`