### PR TITLE
Modified scripts/stac to run python module

### DIFF
--- a/scripts/stac
+++ b/scripts/stac
@@ -8,5 +8,5 @@ fi
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 
-   python ./stactools_cli/stactools/cli "$@"
+   python -m stactools.cli "$@"
 fi


### PR DESCRIPTION
The current scripts/stac script command doesn't work in all environments. This changes the script to run `python -m` against the symlinked sources.