### PR TITLE
Small fixes

### DIFF
--- a/stactools_cli/stactools/cli/commands/copy.py
+++ b/stactools_cli/stactools/cli/commands/copy.py
@@ -51,7 +51,9 @@ def create_copy_command(cli):
                         'be alongside the new item location.'))
     def copy_command(src, dst, catalog_type, copy_assets):
         """Copy a STAC Catalog or Collection at SRC to the directory
-        at DST."""
+        at DST.
+
+        Note: Copying a catalog will upgrade it to the latest version of STAC."""
         source_catalog = pystac.read_file(src)
         copy_catalog(source_catalog, dst, catalog_type, copy_assets)
 

--- a/stactools_cli/stactools/cli/commands/info.py
+++ b/stactools_cli/stactools/cli/commands/info.py
@@ -57,7 +57,8 @@ def create_describe_command(cli):
         short_help='Prints out a list of all catalogs, collections and items '
         'in this STAC.')
     @click.argument('catalog_path')
-    @click.option('--include-hrefs',
+    @click.option('-h',
+                  '--include-hrefs',
                   is_flag=True,
                   help='Include HREFs in description.')
     def describe_command(catalog_path, include_hrefs):

--- a/stactools_core/stactools/core/copy.py
+++ b/stactools_core/stactools/core/copy.py
@@ -193,12 +193,14 @@ def move_all_assets(catalog,
             this function will throw an error unless ignore_conflicts is True.
 
     Returns:
-        [Catalog or Collection]: Returns an updated catalog or collection.
-            Note that this method does not mutate the original catalog.
+        [Catalog or Collection]: Returns the updated catalog.
+            This operation mutates the catalog.
     """
+    for item in catalog.get_all_items():
+        move_assets(item, asset_subdirectory, href_type, copy,
+                    ignore_conflicts)
 
-    return catalog.map_items(lambda item: move_assets(
-        item, asset_subdirectory, href_type, copy, ignore_conflicts))
+    return catalog
 
 
 def copy_catalog(source_catalog,

--- a/stactools_core/stactools/core/merge.py
+++ b/stactools_core/stactools/core/merge.py
@@ -109,9 +109,9 @@ def merge_all_items(source_catalog,
         target_catalog.add_item(item_copy)
 
         if isinstance(target_catalog, pystac.Collection):
-            item.set_collection(target_catalog)
+            item_copy.set_collection(target_catalog)
         else:
-            item.set_collection(None)
+            item_copy.set_collection(None)
 
         if move_assets:
             do_move_assets(item_copy,

--- a/stactools_core/stactools/core/merge.py
+++ b/stactools_core/stactools/core/merge.py
@@ -118,4 +118,7 @@ def merge_all_items(source_catalog,
                            href_type=pystac.LinkType.RELATIVE,
                            copy=False)
 
+    if target_catalog.STAC_OBJECT_TYPE == pystac.STACObjectType.COLLECTION:
+        target_catalog.update_extent_from_items()
+
     return target_catalog

--- a/stactools_core/stactools/core/merge.py
+++ b/stactools_core/stactools/core/merge.py
@@ -5,7 +5,8 @@ from pystac.layout import BestPracticesLayoutStrategy
 from pystac.utils import (is_absolute_href, make_relative_href)
 from shapely.geometry import shape, mapping
 
-from stactools.core.copy import (move_asset_file_to_item)
+from stactools.core.copy import (move_asset_file_to_item, move_assets as
+                                 do_move_assets)
 
 
 def merge_items(source_item,
@@ -113,8 +114,8 @@ def merge_all_items(source_catalog,
             item.set_collection(None)
 
         if move_assets:
-            move_assets(item_copy,
-                        href_type=pystac.LinkType.RELATIVE,
-                        copy=False)
+            do_move_assets(item_copy,
+                           href_type=pystac.LinkType.RELATIVE,
+                           copy=False)
 
     return target_catalog

--- a/stactools_planet/stactools/planet/constants.py
+++ b/stactools_planet/stactools/planet/constants.py
@@ -1,5 +1,7 @@
 import pystac
 
+PLANET_EXTENSION_PREFIX = 'pl'
+
 PLANET_PROVIDER = pystac.Provider(
     name='Planet',
     description=(

--- a/stactools_planet/stactools/planet/planet_item.py
+++ b/stactools_planet/stactools/planet/planet_item.py
@@ -8,6 +8,7 @@ from pystac.utils import (str_to_datetime, make_absolute_href)
 from shapely.geometry import shape
 
 from stactools.planet import PLANET_PROVIDER
+from stactools.planet.constants import PLANET_EXTENSION_PREFIX
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +64,10 @@ class PlanetItem:
         if 'epsg_code' in props:
             item.ext.enable('projection')
             item.ext.projection.epsg = props.pop('epsg_code')
+
+        # Add all additional properties with Planet extension designation.
+        for k, v in props.items():
+            item.properties['{}:{}'.format(PLANET_EXTENSION_PREFIX, k)] = v
 
         for planet_asset in self.item_assets:
             href = make_absolute_href(planet_asset['path'],

--- a/tests/cli/commands/test_copy.py
+++ b/tests/cli/commands/test_copy.py
@@ -1,30 +1,21 @@
 import os
-import unittest
 from tempfile import TemporaryDirectory
 
-import click
-from click.testing import CliRunner
 import pystac
 
 from stactools.cli.commands.copy import create_copy_command
-from tests.utils import TestCases
+from tests.utils import (TestCases, CliTestCase)
 
 
-class CopyTest(unittest.TestCase):
-    def setUp(self):
-        @click.group()
-        def cli():
-            pass
-
-        create_copy_command(cli)
-        self.cli = cli
+class CopyTest(CliTestCase):
+    def create_subcommand_functions(self):
+        return [create_copy_command]
 
     def test_copy(self):
         cat = TestCases.planet_disaster()
         item_ids = set([i.id for i in cat.get_all_items()])
         with TemporaryDirectory() as tmp_dir:
-            runner = CliRunner()
-            runner.invoke(self.cli, ['copy', cat.get_self_href(), tmp_dir])
+            self.run_command(['copy', cat.get_self_href(), tmp_dir])
 
             copy_cat = pystac.read_file(
                 os.path.join(tmp_dir, 'collection.json'))

--- a/tests/cli/commands/test_merge.py
+++ b/tests/cli/commands/test_merge.py
@@ -1,0 +1,56 @@
+import os
+from tempfile import TemporaryDirectory
+
+import pystac
+
+from stactools.cli.commands.merge import create_merge_command
+from stactools.core import move_all_assets
+from tests.utils import (TestCases, CliTestCase)
+
+
+def copy_two_planet_disaster_subsets(tmp_dir):
+    """Test setup util that makes two copies of subset of the planet
+    disaster data, each containing a single item. Updates the collection
+    extents to match the single items.
+
+    Returns a list of collection paths in the temporary directory.
+    """
+    item_ids = ['20170831_172754_101c', '20170831_162740_ssc1d1']
+    new_cols = []
+    for item_id in item_ids:
+        col = TestCases.planet_disaster()
+        for item in list(col.get_all_items()):
+            if item.id != item_id:
+                item.get_parent().remove_item(item.id)
+        col.update_extent_from_items()
+        col.normalize_hrefs(os.path.join(tmp_dir, item_id))
+        col.save(catalog_type=pystac.CatalogType.SELF_CONTAINED)
+        col = move_all_assets(col, copy=True)
+        col.save()
+        new_cols.append(col.get_self_href())
+
+    return new_cols
+
+
+class MergeTest(CliTestCase):
+    def create_subcommand_functions(self):
+        return [create_merge_command]
+
+    def test_merge_moves_assets(self):
+        with TemporaryDirectory() as tmp_dir:
+            col_paths = copy_two_planet_disaster_subsets(tmp_dir)
+
+            cmd = ['merge', '-a', col_paths[0], col_paths[1]]
+
+            self.run_command(cmd)
+
+            target_col = pystac.read_file(col_paths[1])
+
+            items = list(target_col.get_all_items())
+            self.assertEqual(len(items), 2)
+
+            for item in items:
+                for asset in item.assets.values():
+                    self.assertEqual(
+                        os.path.dirname(asset.get_absolute_href()),
+                        os.path.dirname(item.get_self_href()))

--- a/tests/cli/commands/test_merge.py
+++ b/tests/cli/commands/test_merge.py
@@ -25,7 +25,7 @@ def copy_two_planet_disaster_subsets(tmp_dir):
         col.update_extent_from_items()
         col.normalize_hrefs(os.path.join(tmp_dir, item_id))
         col.save(catalog_type=pystac.CatalogType.SELF_CONTAINED)
-        col = move_all_assets(col, copy=True)
+        move_all_assets(col, copy=True)
         col.save()
         new_cols.append(col.get_self_href())
 

--- a/tests/planet/test_commands.py
+++ b/tests/planet/test_commands.py
@@ -46,3 +46,5 @@ class ConvertOrderTest(unittest.TestCase):
                 self.assertTrue(os.path.exists(asset.get_absolute_href()))
                 self.assertEqual(os.path.dirname(asset.get_absolute_href()),
                                  os.path.dirname(item.get_self_href()))
+
+            self.assertEqual(item.properties.get('pl:quality_category'), 'standard')

--- a/tests/planet/test_commands.py
+++ b/tests/planet/test_commands.py
@@ -1,36 +1,26 @@
 import os
-import unittest
 from tempfile import TemporaryDirectory
 
-import click
-from click.testing import CliRunner
 import pystac
 
 from stactools.planet.commands import create_planet_command
-from tests.utils import TestCases
+from tests.utils import (TestCases, CliTestCase)
 
 
-class ConvertOrderTest(unittest.TestCase):
-    def setUp(self):
-        @click.group()
-        def cli():
-            pass
-
-        create_planet_command(cli)
-        self.cli = cli
+class ConvertOrderTest(CliTestCase):
+    def create_subcommand_functions(self):
+        return [create_planet_command]
 
     def test_converts(self):
         test_order_manifest = TestCases.get_path(
             'data-files/planet-order/manifest.json')
 
         with TemporaryDirectory() as tmp_dir:
-            runner = CliRunner()
-            result = runner.invoke(self.cli, [
+            result = self.run_command([
                 'planet', 'convert-order', test_order_manifest, tmp_dir,
                 'test_id', 'A test catalog', '--title', 'test-catalog', '-a',
                 'copy'
-            ],
-                                   catch_exceptions=False)
+            ])
 
             self.assertEqual(result.exit_code,
                              0,
@@ -47,4 +37,5 @@ class ConvertOrderTest(unittest.TestCase):
                 self.assertEqual(os.path.dirname(asset.get_absolute_href()),
                                  os.path.dirname(item.get_self_href()))
 
-            self.assertEqual(item.properties.get('pl:quality_category'), 'standard')
+            self.assertEqual(item.properties.get('pl:quality_category'),
+                             'standard')

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,3 +1,4 @@
 # flake8: noqa
 
 from tests.utils.test_cases import TestCases
+from tests.utils.cli_test import CliTestCase

--- a/tests/utils/cli_test.py
+++ b/tests/utils/cli_test.py
@@ -1,0 +1,25 @@
+from abc import (ABC, abstractmethod)
+import unittest
+
+import click
+from click.testing import CliRunner
+
+
+class CliTestCase(unittest.TestCase, ABC):
+    def setUp(self):
+        @click.group()
+        def cli():
+            pass
+
+        for create_subcommand in self.create_subcommand_functions():
+            create_subcommand(cli)
+        self.cli = cli
+
+    def run_command(self, cmd):
+        runner = CliRunner()
+        return runner.invoke(self.cli, cmd, catch_exceptions=False)
+
+    @abstractmethod
+    def create_subcommand_functions(self):
+        """Return list of 'create_command' functions from implementations"""
+        pass


### PR DESCRIPTION
This PR includes a set of small fixes:
- Include all Planet item metadata, using 'pl:' for a prefix to any metadata that doesn't map to STAC
- Fixed bug in `stac merge` when copying assets
- Update collection extents when using `stac merge`
- Add `-h` as shortcut for `--include-hrefs` option in `stac describe`.
- Add docs to note that `stac copy` will migrate the copied STAC to the latest version.

Also refactored the unit tests to make writing CLI test a bit more consistent.