### PR TITLE
Fix issues with asset HREFs 

### DIFF
--- a/stactools_cli/stactools/cli/cli.py
+++ b/stactools_cli/stactools/cli/cli.py
@@ -37,7 +37,7 @@ for create_subcommand in registry.get_create_subcommand_functions():
 
 
 def run_cli():
-    cli(prog_name='stactools')
+    cli(prog_name='stac')
 
 
 if __name__ == "__main__":

--- a/stactools_cli/stactools/cli/commands/copy.py
+++ b/stactools_cli/stactools/cli/commands/copy.py
@@ -9,25 +9,34 @@ def create_move_assets_command(cli):
         'move-assets',
         short_help='Move or copy assets in a STAC to the Item locations.')
     @click.argument('catalog_path')
-    @click.option('-c', '--copy', help='Copy assets instead of moving.', is_flag=True)
+    @click.option('-c',
+                  '--copy',
+                  help='Copy assets instead of moving.',
+                  is_flag=True)
     @click.option('-s',
                   '--asset-subdirectory',
                   help=('Subdirectory to place assets '
                         'inside of the directory containing '
                         'their items'))
-    @click.option(
-        '-h',
-        '--href-type',
-        type=click.Choice([pystac.LinkType.ABSOLUTE, pystac.LinkType.RELATIVE],
-                          case_sensitive=False),
-        help=('If supplied, forces asset HREFs to be either absolute or '
-              'relative HREFS'))
-    def move_assets_command(catalog_path, copy, asset_subdirectory, href_type):
+    def move_assets_command(catalog_path, copy, asset_subdirectory):
+        """Move or copy assets in a STAC Catalog.
+
+        For all assets in the catalog at CATALOG_PATH, move or copy
+        those assets into the directory of the item for which they belong.
+        If --asset-subdirectory is used, moves them instead into a directory
+        called 'assets' next to the item for which they belong. If -c is used,
+        assets are copied; otherwise they are moved.
+
+        Note: If the catalog is an ABSOLUTE_PUBLISHED catalog, the assets will have
+        an absolute HREF after this operation. Otherwise, it will have a relative HREF.
+        """
         catalog = pystac.read_file(catalog_path)
-        move_all_assets(catalog,
-                        asset_subdirectory=asset_subdirectory,
-                        href_type=href_type,
-                        copy=copy)
+
+        processed = move_all_assets(catalog,
+                                    asset_subdirectory=asset_subdirectory,
+                                    copy=copy)
+
+        processed.save()
 
     return move_assets_command
 

--- a/stactools_cli/stactools/cli/commands/copy.py
+++ b/stactools_cli/stactools/cli/commands/copy.py
@@ -9,7 +9,7 @@ def create_move_assets_command(cli):
         'move-assets',
         short_help='Move or copy assets in a STAC to the Item locations.')
     @click.argument('catalog_path')
-    @click.option('-c', '--copy', help='Copy assets instead of moving.')
+    @click.option('-c', '--copy', help='Copy assets instead of moving.', is_flag=True)
     @click.option('-s',
                   '--asset-subdirectory',
                   help=('Subdirectory to place assets '

--- a/stactools_core/requirements.txt
+++ b/stactools_core/requirements.txt
@@ -1,4 +1,4 @@
-pystac[validation]==0.5.3
+pystac[validation]==0.5.4
 aiohttp==3.7.3
 fsspec==0.8.4
 requests==2.25.0

--- a/stactools_core/stactools/core/copy.py
+++ b/stactools_core/stactools/core/copy.py
@@ -112,8 +112,8 @@ def move_asset_file_to_item(item,
 
                     op = _op
 
-    if op is not None:
-        op(dry_run=False)
+        if op is not None:
+            op(dry_run=False)
 
     return new_asset_href
 

--- a/stactools_core/stactools/core/merge.py
+++ b/stactools_core/stactools/core/merge.py
@@ -43,7 +43,6 @@ def merge_items(source_item,
                 new_asset_href = move_asset_file_to_item(
                     target_item,
                     asset_href,
-                    href_type=pystac.LinkType.RELATIVE,
                     ignore_conflicts=ignore_conflicts)
             else:
                 asset_href = asset.get_absolute_href()
@@ -114,9 +113,7 @@ def merge_all_items(source_catalog,
             item_copy.set_collection(None)
 
         if move_assets:
-            do_move_assets(item_copy,
-                           href_type=pystac.LinkType.RELATIVE,
-                           copy=False)
+            do_move_assets(item_copy, copy=False)
 
     if target_catalog.STAC_OBJECT_TYPE == pystac.STACObjectType.COLLECTION:
         target_catalog.update_extent_from_items()

--- a/stactools_core/stactools/core/merge.py
+++ b/stactools_core/stactools/core/merge.py
@@ -41,9 +41,7 @@ def merge_items(source_item,
             if move_assets:
                 asset_href = asset.get_absolute_href()
                 new_asset_href = move_asset_file_to_item(
-                    target_item,
-                    asset_href,
-                    ignore_conflicts=ignore_conflicts)
+                    target_item, asset_href, ignore_conflicts=ignore_conflicts)
             else:
                 asset_href = asset.get_absolute_href()
                 if not is_absolute_href(asset.href):

--- a/tests/cli/commands/test_copy.py
+++ b/tests/cli/commands/test_copy.py
@@ -1,7 +1,9 @@
 import os
 from tempfile import TemporaryDirectory
+from typing import cast
 
 import pystac
+from pystac.utils import is_absolute_href, make_absolute_href
 
 from stactools.cli.commands.copy import create_copy_command
 from tests.utils import (TestCases, CliTestCase)
@@ -22,3 +24,39 @@ class CopyTest(CliTestCase):
             copy_cat_ids = set([i.id for i in copy_cat.get_all_items()])
 
             self.assertEqual(copy_cat_ids, item_ids)
+
+    def test_copy_to_relative(self):
+        cat = TestCases.planet_disaster()
+
+        with TemporaryDirectory() as tmp_dir:
+            cat.make_all_asset_hrefs_absolute()
+            cat.normalize_hrefs(tmp_dir)
+            cat.save(catalog_type=pystac.CatalogType.ABSOLUTE_PUBLISHED)
+
+            cat2_dir = os.path.join(tmp_dir, 'second')
+
+            command = [
+                'copy',
+                '-t', 'SELF_CONTAINED',
+                '-a',
+                cat.get_self_href(),
+                cat2_dir
+            ]
+            self.run_command(command)
+            cat2 = pystac.read_file(os.path.join(cat2_dir, 'collection.json'))
+            for item in cat2.get_all_items():
+                item_href = item.get_self_href()
+                for asset in item.assets.values():
+                    href = asset.href
+                    self.assertFalse(is_absolute_href(href))
+                    common_path = os.path.commonpath([
+                        os.path.dirname(item_href),
+                        make_absolute_href(href, item_href)
+                    ])
+                    self.assertTrue(common_path, os.path.dirname(item_href))
+
+
+
+
+
+

--- a/tests/utils/cli_test.py
+++ b/tests/utils/cli_test.py
@@ -17,7 +17,10 @@ class CliTestCase(unittest.TestCase, ABC):
 
     def run_command(self, cmd):
         runner = CliRunner()
-        return runner.invoke(self.cli, cmd, catch_exceptions=False)
+        result = runner.invoke(self.cli, cmd, catch_exceptions=False)
+        if result.output:
+            print(result.output)
+        return result
 
     @abstractmethod
     def create_subcommand_functions(self):


### PR DESCRIPTION
This PR adds changes to address the issues brought up in #30 and #31:

- Upgrades to PySTAC 0.5.4, which has a change that now modifies the asset HREF the same way as link HREFs based on Catalog Type - if ABSOLUTE_PUBLISHED, the asset hrefs will be absolute. If RELATIVE_PUBLISHED or SELF_CONTAINED, the asset HREFs will be relative if they possible (e.g. if they are both on the local filesystem). This addresses #31
- Fixes a typo that was causing exception described in #30 
- Fixes the `Error: Missing argument 'CATALOG_PATH'.` error which was being caused by a flag missing the click `is_flag=True` parameter
- Fixes an issue where move-assets wasn't being saved. It also removes the "--href-type" option from move-assets, as the catalog type now dictates whether asset hrefs are absolute or relative. This addresses the final point in #30

Fixes #30 
Fixes #31