### PR TITLE
Fix issue caused by shapely bounds returning tuple.

### DIFF
--- a/stactools_aster/stactools/aster/cog.py
+++ b/stactools_aster/stactools/aster/cog.py
@@ -50,8 +50,7 @@ def _create_cog(item, href, subdatasets, bands):
     geom = item.geometry
     crs = 'epsg:{}'.format(item.ext.projection.epsg)
     reprojected_geom = reproject_geom('epsg:4326', crs, geom)
-    bounds = shape(reprojected_geom).bounds
-    print(bounds)
+    bounds = list(shape(reprojected_geom).bounds)
 
     with TemporaryDirectory() as tmp_dir:
         band_paths = []

--- a/stactools_core/stactools/core/merge.py
+++ b/stactools_core/stactools/core/merge.py
@@ -56,7 +56,7 @@ def merge_items(source_item,
     target_geom = shape(target_item.geometry)
     union_geom = source_geom.union(target_geom).buffer(0)
     target_item.geometry = mapping(union_geom)
-    target_item.bbox = union_geom.bounds
+    target_item.bbox = list(union_geom.bounds)
 
 
 def merge_all_items(source_catalog,


### PR DESCRIPTION
There were instances of setting a shapely geometry bounds attribute
directly as item bounds. This can cause issues as items require bounds
to be a list.

This commit wraps shapely bounds usage into lists and tests around the
failure case.