### PR TITLE
Add naip as a extra subpackage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ subpackages = [
     Subpackage('aster', is_extra=True),
     Subpackage('corine', is_extra=True),
     Subpackage('landsat', is_extra=True),
+    Subpackage('naip', is_extra=True),
     Subpackage('planet', is_extra=True),
     Subpackage('browse', is_extra=True),
 ]


### PR DESCRIPTION
Fixes the `setup.py` to add naip as an extras subpackage, which is necessary for enabling users to `pip install stactools[naip]`