### PR TITLE
Ensure asset paths are absolute in Sentinel2 create_item

### DIFF
--- a/stactools_sentinel2/stactools/sentinel2/stac.py
+++ b/stactools_sentinel2/stactools/sentinel2/stac.py
@@ -110,7 +110,7 @@ def create_item(
     proj_bbox = granule_metadata.proj_bbox
 
     image_assets = dict([
-        image_asset_from_href(image_path, item,
+        image_asset_from_href(os.path.join(granule_href, image_path), item,
                               granule_metadata.resolution_to_shape, proj_bbox,
                               product_metadata.image_media_type)
         for image_path in product_metadata.image_paths

--- a/tests/sentinel2/test_commands.py
+++ b/tests/sentinel2/test_commands.py
@@ -2,6 +2,7 @@ import os
 from tempfile import TemporaryDirectory
 
 import pystac
+from pystac.utils import is_absolute_href
 from shapely.geometry import box, shape, mapping
 
 from stactools.core.projection import reproject_geom
@@ -54,4 +55,8 @@ class CreateItemTest(CliTestCase):
                         item = pystac.read_file(os.path.join(tmp_dir, fname))
 
                         item.validate()
+
+                        for asset in item.assets.values():
+                            self.assertTrue(is_absolute_href(asset.href))
+
                         check_proj_bbox(item)


### PR DESCRIPTION
This PR fixes an issue where the image assets were using the paths to the assets relative to the granule directory, and adds a unit test to cover this case.