### PR TITLE
Sentinel2: Use band id as the asset keys for image band assets.

### DIFF
--- a/stactools_sentinel2/stactools/sentinel2/stac.py
+++ b/stactools_sentinel2/stactools/sentinel2/stac.py
@@ -116,8 +116,9 @@ def create_item(
         for image_path in product_metadata.image_paths
     ])
 
-    for asset in image_assets.items():
-        item.add_asset(*asset)
+    for key, asset in image_assets.items():
+        assert key not in item.assets
+        item.add_asset(key, asset)
 
     # Thumbnail
 
@@ -205,7 +206,7 @@ def image_asset_from_href(
                              roles=['data'])
         item.ext.eo.set_bands([SENTINEL_BANDS[band_id]], asset)
         set_asset_properties(asset)
-        return (asset_href[-7:].replace('_', '-'), asset)
+        return (band_id, asset)
 
     # Handle auxiliary images
 

--- a/tests/sentinel2/test_commands.py
+++ b/tests/sentinel2/test_commands.py
@@ -7,6 +7,7 @@ from shapely.geometry import box, shape, mapping
 
 from stactools.core.projection import reproject_geom
 from stactools.sentinel2.commands import create_sentinel2_command
+from stactools.sentinel2.constants import SENTINEL_BANDS
 from tests.utils import (TestData, CliTestCase)
 
 
@@ -56,7 +57,15 @@ class CreateItemTest(CliTestCase):
 
                         item.validate()
 
+                        bands_seen = set()
+
                         for asset in item.assets.values():
                             self.assertTrue(is_absolute_href(asset.href))
+                            bands = item.ext.eo.get_bands(asset)
+                            if bands is not None:
+                                bands_seen |= set(b.name for b in bands)
+
+                        self.assertEqual(bands_seen,
+                                         set(SENTINEL_BANDS.keys()))
 
                         check_proj_bbox(item)


### PR DESCRIPTION
This fixes an issue where the asset keys for band assets weren't being set properly. This also tests that they do not overwrite existing band asset keys (which was happening prior to this PR) and tests that all bands are represented in the assets.