### PR TITLE
Fix bug with ASTER cog generation.

### DIFF
--- a/stactools_aster/stactools/aster/cog.py
+++ b/stactools_aster/stactools/aster/cog.py
@@ -33,19 +33,19 @@ def merge_bands(input_paths, output_path):
     call(['gdal_merge.py', '-separate', '-o', output_path] + input_paths)
 
 
-def cogify(input_path, output_path):
-    call([
-        'gdal_translate', '-of', 'COG', '-co', 'compress=deflate', input_path,
-        output_path
-    ])
-
-
 def set_band_names(href: str, band_names: List[str]) -> None:
     with rio.open(href) as ds:
         profile = ds.profile
 
-    with rio.open(href, 'w', **profile) as ds:
+    with rio.open(href, 'r+', **profile) as ds:
         ds.descriptions = band_names
+
+
+def cogify(input_path, output_path):
+    call([
+        'gdal_translate', '-of', 'COG', '-co', 'predictor=2', '-co',
+        'compress=deflate', input_path, output_path
+    ])
 
 
 def _create_cog_for_sensor(sensor: str, file_prefix: str, tmp_dir: str,
@@ -68,9 +68,9 @@ def _create_cog_for_sensor(sensor: str, file_prefix: str, tmp_dir: str,
     merged_path = os.path.join(sensor_dir, 'merged.tif')
     merge_bands(band_paths, merged_path)
 
-    cogify(merged_path, sensor_cog_href)
+    set_band_names(merged_path, band_names)
 
-    set_band_names(sensor_cog_href, band_names)
+    cogify(merged_path, sensor_cog_href)
 
     return sensor_cog_href
 

--- a/tests/aster/test_commands.py
+++ b/tests/aster/test_commands.py
@@ -89,12 +89,14 @@ class CreateItemTest(CliTestCase):
                     'AST_L1T_00305032000040446_20150409135350_78838-TIR.tif'
                 ]))
 
-            # Check band names
+            # Check band names, and that there is variable data
             for cog in cogs:
                 sensor = os.path.splitext(cog)[0].split('-')[-1]
                 with rio.open(os.path.join(tmp_dir, cog)) as ds:
                     for band_name in ds.descriptions:
                         self.assertTrue(sensor in band_name)
+
+                    self.assertTrue(ds.read().any())
 
             vnir_cog_fname = next(c for c in cogs if 'VNIR' in c)
             swir_cog_fname = next(c for c in cogs if 'SWIR' in c)


### PR DESCRIPTION
There's a bug in the ASTER COG generation that was overwriting file data 🤦‍♂️ 

This PR adds a test that fails without the fix, uses the correct rasterio open mode (`r+`), and reorders the generation steps to put cogification last as the metadata set step writes the IFD at the end of the file, breaking COG.

Also, use predictor=2  for slightly better compression.