### PR TITLE
Update Landsat 8 Collection 2 Level 2 asset keys

### DIFF
--- a/stactools_landsat/stactools/landsat/assets.py
+++ b/stactools_landsat/stactools/landsat/assets.py
@@ -48,7 +48,8 @@ class AssetDef:
 
     def add_asset(self, item: pystac.Item, mtl_metadata: MtlMetadata,
                   base_href: str) -> None:
-        asset = pystac.Asset(href=self.get_href(base_href))
+        asset = pystac.Asset(href=self.get_href(base_href),
+                             media_type=self.media_type)
         if self.title:
             asset.title = self.title
         if self.description:

--- a/stactools_landsat/stactools/landsat/assets.py
+++ b/stactools_landsat/stactools/landsat/assets.py
@@ -15,7 +15,7 @@ class AssetDef:
     def __init__(self,
                  href_suffix: str,
                  media_type: str,
-                 key: Optional[str] = None,
+                 key: str,
                  title: Optional[str] = None,
                  description: Optional[str] = None,
                  bands: Optional[List[Band]] = None,
@@ -95,32 +95,38 @@ PREVIEW_ASSET_DEF = AssetDef(key="reduced_resolution_browse",
                              media_type=pystac.MediaType.JPEG)
 ANG_ASSET_DEF = AssetDef(
     href_suffix="ANG.txt",
+    key="ANG",
     title="Angle Coefficients File",
     description=("Collection 2 Level-1 Angle Coefficients File (ANG)"),
     media_type=pystac.MediaType.TEXT)
 MTL_TXT_ASSET_DEF = AssetDef(
     href_suffix="MTL.txt",
+    key="MTL.txt",
     title="Product Metadata File",
     description=("Collection 2 Level-1 Product Metadata File (MTL)"),
     media_type=pystac.MediaType.TEXT)
 MTL_XML_ASSET_DEF = AssetDef(
     href_suffix="MTL.xml",
+    key="MTL.xml",
     title="Product Metadata File (xml)",
     description="Collection 2 Level-1 Product Metadata File (xml)",
     media_type=pystac.MediaType.XML)
 MTL_JSON_ASSET_DEF = AssetDef(
     href_suffix="MTL.json",
+    key="MTL.json",
     title="Product Metadata File (json)",
     description="Collection 2 Level-1 Product Metadata File (json)",
     media_type=pystac.MediaType.JSON)
 QA_PIXEL_ASSET_DEF = AssetDef(
     href_suffix="QA_PIXEL.TIF",
+    key="QA_PIXEL",
     title="Pixel Quality Assessment Band",
     description="Collection 2 Level-1 Pixel Quality Assessment Band",
     media_type=pystac.MediaType.COG,
     is_qa=True)
 QA_RADSAT_ASSET_DEF = AssetDef(
     href_suffix="QA_RADSAT.TIF",
+    key="QA_RADSAT",
     title="Radiometric Saturation Quality Assessment Band",
     description=("Collection 2 Level-1 Radiometric Saturation "
                  "Quality Assessment Band"),
@@ -138,24 +144,28 @@ COMMON_ASSET_DEFS = [
 # and Level 2 Surface Reflectance (L2SR) processing levels
 B1_ASSET_DEF = AssetDef(
     href_suffix="SR_B1.TIF",
+    key="SR_B1",
     title="Coastal/Aerosol Band (B1)",
     description=("Collection 2 Level-2 Coastal/Aerosol Band "
                  "(B1) Surface Reflectance"),
     media_type=pystac.MediaType.COG,
     is_sr=True)
 B2_ASSET_DEF = AssetDef(href_suffix="SR_B2.TIF",
+                        key="SR_B2",
                         title="Blue Band (B2)",
                         description=("Collection 2 Level-2 Blue Band "
                                      "(B2) Surface Reflectance"),
                         media_type=pystac.MediaType.COG,
                         is_sr=True)
 B3_ASSET_DEF = AssetDef(href_suffix="SR_B3.TIF",
+                        key="SR_B3",
                         title="Green Band (B3)",
                         description=("Collection 2 Level-2 Green Band "
                                      "(B3) Surface Reflectance"),
                         media_type=pystac.MediaType.COG,
                         is_sr=True)
 B4_ASSET_DEF = AssetDef(href_suffix="SR_B4.TIF",
+                        key="SR_B4",
                         title="Red Band (B4)",
                         description=("Collection 2 Level-2 Red Band "
                                      "(B4) Surface Reflectance"),
@@ -163,6 +173,7 @@ B4_ASSET_DEF = AssetDef(href_suffix="SR_B4.TIF",
                         is_sr=True)
 B5_ASSET_DEF = AssetDef(
     href_suffix="SR_B5.TIF",
+    key="SR_B5",
     title="Near Infrared Band 0.8 (B5)",
     description=("Collection 2 Level-2 Near Infrared Band 0.8 "
                  "(B5) Surface Reflectance"),
@@ -170,6 +181,7 @@ B5_ASSET_DEF = AssetDef(
     is_sr=True)
 B6_ASSET_DEF = AssetDef(
     href_suffix="SR_B6.TIF",
+    key="SR_B6",
     title="Short-wave Infrared Band 1.6 (B6)",
     description=("Collection 2 Level-2 Short-wave Infrared Band 1.6 "
                  "(B6) Surface Reflectance"),
@@ -177,6 +189,7 @@ B6_ASSET_DEF = AssetDef(
     is_sr=True)
 B7_ASSET_DEF = AssetDef(
     href_suffix="SR_B7.TIF",
+    key="SR_B7",
     title="Short-wave Infrared Band 2.2 (B7)",
     description=("Collection 2 Level-2 Short-wave Infrared Band 2.2 "
                  "(B7) Surface Reflectance"),
@@ -184,6 +197,7 @@ B7_ASSET_DEF = AssetDef(
     is_sr=True)
 QA_AEROSOL_ASSET_DEF = AssetDef(
     href_suffix="SR_QA_AEROSOL.TIF",
+    key="SR_B8",
     title="Aerosol Quality Analysis Band",
     description=("Collection 2 Level-2 Aerosol Quality Analysis Band "
                  "(ANG) Surface Reflectance"),
@@ -202,7 +216,8 @@ ST_B10_ASSET_DEF = AssetDef(
     # COG has Pixel Size of 30m,
     # but 100m spatial resolution at the sensor
     gsd=100.0,
-    href_suffix="ST_B10.tif",
+    href_suffix="ST_B10.TIF",
+    key="ST_B10",
     title="Surface Temperature Band (B10)",
     description=("Landsat Collection 2 Level-2 Surface Temperature Band "
                  "(B10) Surface Temperature Product"),
@@ -210,7 +225,8 @@ ST_B10_ASSET_DEF = AssetDef(
     is_thermal=True)
 
 ST_ATRAN_ASSET_DEF = AssetDef(
-    href_suffix="ST_ATRAN.tif",
+    href_suffix="ST_ATRAN.TIF",
+    key="ST_ATRAN",
     title="Atmospheric Transmittance Band",
     description=("Landsat Collection 2 Level-2 Atmospheric "
                  "Transmittance Band Surface Temperature Product"),
@@ -218,7 +234,8 @@ ST_ATRAN_ASSET_DEF = AssetDef(
     is_thermal=True)
 
 ST_CDIST_ASSET_DEF = AssetDef(
-    href_suffix="ST_CDIST.tif",
+    href_suffix="ST_CDIST.TIF",
+    key="ST_CDIST",
     title="Cloud Distance Band",
     description=("Landsat Collection 2 Level-2 Cloud Distance Band "
                  "Surface Temperature Product"),
@@ -227,6 +244,7 @@ ST_CDIST_ASSET_DEF = AssetDef(
 
 ST_DRAD_ASSET_DEF = AssetDef(
     href_suffix="ST_DRAD.tif",
+    key="ST_DRAD",
     title="Downwelled Radiance Band",
     description=("Landsat Collection 2 Level-2 Downwelled "
                  "Radiance Band Surface Temperature Product"),
@@ -234,7 +252,8 @@ ST_DRAD_ASSET_DEF = AssetDef(
     is_thermal=True)
 
 ST_URAD_ASSET_DEF = AssetDef(
-    href_suffix="ST_URAD.tif",
+    href_suffix="ST_URAD.TIF",
+    key="ST_URAD",
     title="Upwelled Radiance Band",
     description=("Landsat Collection 2 Level-2 Upwelled "
                  "Radiance Band Surface Temperature Product"),
@@ -242,7 +261,8 @@ ST_URAD_ASSET_DEF = AssetDef(
     is_thermal=True)
 
 ST_TRAD_ASSET_DEF = AssetDef(
-    href_suffix="ST_TRAD.tif",
+    href_suffix="ST_TRAD.TIF",
+    key="ST_TRAD",
     title="Thermal Radiance Band",
     description=("Landsat Collection 2 Level-2 Thermal Radiance "
                  "Band Surface Temperature Product"),
@@ -250,7 +270,8 @@ ST_TRAD_ASSET_DEF = AssetDef(
     is_thermal=True)
 
 ST_EMIS_ASSET_DEF = AssetDef(
-    href_suffix="ST_EMIS.tif",
+    href_suffix="ST_EMIS.TIF",
+    key="ST_EMIS",
     title="Emissivity Band",
     description=("Landsat Collection 2 Level-2 Emissivity Band "
                  "Surface Temperature Product"),
@@ -258,7 +279,8 @@ ST_EMIS_ASSET_DEF = AssetDef(
     is_thermal=True)
 
 ST_EMSD_ASSET_DEF = AssetDef(
-    href_suffix="ST_EMSD.tif",
+    href_suffix="ST_EMSD.TIF",
+    key="ST_EMSD",
     title="Emissivity Standard Deviation Band",
     description=("Landsat Collection 2 Level-2 Emissivity "
                  "Standard Deviation Band Surface Temperature Product"),
@@ -266,7 +288,8 @@ ST_EMSD_ASSET_DEF = AssetDef(
     is_thermal=True)
 
 ST_QA_ASSET_DEF = AssetDef(
-    href_suffix="ST_QA.tif",
+    href_suffix="ST_QA.TIF",
+    key="ST_QA",
     title="Surface Temperature Quality Assessment Band",
     description=("Landsat Collection 2 Level-2 Surface Temperature "
                  "Band Surface Temperature Product"),

--- a/tests/landsat/test_create_stac.py
+++ b/tests/landsat/test_create_stac.py
@@ -7,6 +7,7 @@ from pystac.utils import is_absolute_href
 from shapely.geometry import box, shape, mapping
 
 from stactools.core.projection import reproject_geom
+from stactools.landsat.assets import SR_ASSET_DEFS, THERMAL_ASSET_DEFS
 from stactools.landsat.commands import create_landsat_command
 from stactools.landsat.constants import (L8_SR_BANDS, L8_SP_BANDS)
 from tests.utils import CliTestCase
@@ -104,6 +105,15 @@ class CreateItemTest(CliTestCase):
                         '--enable-proj', '--dst', convert_dir
                     ]
                     self.run_command(convert_cmd)
+
+                    created_item = get_item(create_dir)
+
+                    for asset_def in SR_ASSET_DEFS:
+                        self.assertIn(asset_def.key, created_item.assets)
+                    if created_item.properties[
+                            'landsat:processing_level'] == 'L2SP':
+                        for asset_def in THERMAL_ASSET_DEFS:
+                            self.assertIn(asset_def.key, created_item.assets)
 
                     # TODO: Resolve disagreements between convert and create.
                     # This might best be informed by USGS's own STAC 1.0.* items

--- a/tests/landsat/test_create_stac.py
+++ b/tests/landsat/test_create_stac.py
@@ -108,6 +108,10 @@ class CreateItemTest(CliTestCase):
 
                     created_item = get_item(create_dir)
 
+                    # Ensure media_type is set
+                    for asset in created_item.assets.values():
+                        self.assertTrue(asset.media_type is not None)
+
                     for asset_def in SR_ASSET_DEFS:
                         self.assertIn(asset_def.key, created_item.assets)
                     if created_item.properties[


### PR DESCRIPTION
The Landsat 8 Collection 2 Level 2 created item asset keys currently has the file extension in the key name. With the current code, there was inconsistent capitalization of the extension. On further consideration, the inclusion of file extensions is consistent with the USGS 0.7 Items but is inconsistent with other STAC items produces. The assets themselves describe the media type and the HREFs have the file extension, and having the file extension in asset key is duplicate information and may be confusing to users. This commit switches to dropping file extensions in key names. The only exception is the MTL file, which has multiple file types - these assets retain their extension to differentiate between the various assets.

In addition, during testing I found that the media_type was not being set correctly on the assets. This PR also fixes this issue.