### PR TITLE
Fix the `--enable-proj` flag for landsat's convert command

### DIFF
--- a/stactools_landsat/stactools/landsat/commands.py
+++ b/stactools_landsat/stactools/landsat/commands.py
@@ -52,7 +52,6 @@ def create_landsat_command(cli):
     @click.option(
         "--enable-proj",
         "-p",
-        default=True,
         is_flag=True,
         help="Enable the proj extension. Requires access to blue band.")
     @click.option("--dst", "-d", help="Output directory")

--- a/tests/landsat/test_commands.py
+++ b/tests/landsat/test_commands.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import os.path
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -113,6 +114,7 @@ class LandsatTest(CliTestCase):
                              0,
                              msg='\n{}'.format(result.output))
 
-            output_stac_file = Path(
-                tmp_dir) / "LC08_L2SR_081119_20200101_20200823_02_T2.json"
-            assert output_stac_file.is_file()
+            output_stac_file = os.path.join(
+                tmp_dir, "LC08_L2SR_081119_20200101_20200823_02_T2.json")
+            item = pystac.Item.from_file(output_stac_file)
+            self.assertEqual(item.ext.projection.epsg, 3031)

--- a/tests/landsat/test_create_stac.py
+++ b/tests/landsat/test_create_stac.py
@@ -101,8 +101,8 @@ class CreateItemTest(CliTestCase):
                         os.path.join(original_dir,
                                      os.path.basename(stac_path)))
                     convert_cmd = [
-                        'landsat', 'convert', '--stac', stac_path,
-                        '--enable-proj', '--dst', convert_dir
+                        'landsat', 'convert', '--stac', stac_path, '--dst',
+                        convert_dir
                     ]
                     self.run_command(convert_cmd)
 


### PR DESCRIPTION
While reviewing #91, I discovered that the `landsat convert --enable-proj` flag was not working. This PR adds an initially-failing test and a fix.

I implemented this fix to keep as much existing behavior as possible, namely keeping the `--enable-proj` as a flag. However, the more click-y way of doing this would be to switch to a `--proj/--no-proj` flag. If the reviewer thinks that `--proj/--no-proj` would be better, it wouldn't be hard to do that instead, but it would require changing a couple more tests (and possibly downstream users' cli arguments).