### PR TITLE
Update to v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,35 @@
 
 ## [unreleased]
 
+## stactools 0.1.5
+
 ### Added
+
+- Method for creating Copernicus Land Cover Layers ([#50](https://github.com/stac-utils/stactools/pull/50))
+- `eo:bands` information for Planet SkySat assets ([#40](https://github.com/stac-utils/stactools/issues/40))
+- Roles and thumbnails for Planet assets ([#46](https://github.com/stac-utils/stactools/issues/46) and [#49](https://github.com/stac-utils/stactools/issues/49))
+- Projection information for Planet items ([#39](https://github.com/stac-utils/stactools/issues/39))
+- Azimuth values in the view namespace for Planet ([#59](https://github.com/stac-utils/stactools/issues/59))
+- More Planet properties ([#57](https://github.com/stac-utils/stactools/issues/57))
+- Add "via" rel link for Planet data ([#58](https://github.com/stac-utils/stactools/issues/58))
+- Sentinel-2 item creation ([#52](https://github.com/stac-utils/stactools/pull/52))
+- Top level symlink directory to help the dev environment.
+- Merge command ([#75](https://github.com/stac-utils/stactools/pull/75))
+- USGS 3DEP support as `threedep` ([#81](https://github.com/stac-utils/stactools/pull/81))
 
 ### Changed
 
+- Allow debug output in unit tests
+- Updates to `aster`, `landsat`, and `sentinel2` subpackages ([#83](https://github.com/stac-utils/stactools/pull/83))
+
 ### Fixed
+
+- Landsat projection extraction ([#67](https://github.com/stac-utils/stactools/pull/67) and [#100](https://github.com/stac-utils/stactools/pull/100))
+- Installing `naip` subpackage ([#72](https://github.com/stac-utils/stactools/pull/72))
+- Clean up planet test data ([#74](https://github.com/stac-utils/stactools/pull/74))
+- `aster` COG generation ([#89](https://github.com/stac-utils/stactools/pull/89))
+- `landsat` asset keys ([#90](https://github.com/stac-utils/stactools/pull/90))
+- Docs ([#93](https://github.com/stac-utils/stactools/pull/93))
 
 ## stactools 0.1.4
 
@@ -34,7 +58,7 @@
 ### Fixed
 
 - Fixed issues with copying and asset movint ([#34](https://github.com/stac-utils/stactools/pull/34))
-- Fix `stac browse` with upgrades to versions in the tiler container ([#35g](https://github.com/stac-utils/stactools/pull/35))
+- Fix `stac browse` with upgrades to versions in the tiler container ([#35](https://github.com/stac-utils/stactools/pull/35))
 
 ## stactools 0.1.1
 

--- a/stactools_aster/stactools/aster/version.py
+++ b/stactools_aster/stactools/aster/version.py
@@ -1,2 +1,2 @@
-__version__ = '0.1.4'
+__version__ = '0.1.5'
 """Library version"""

--- a/stactools_browse/stactools/browse/version.py
+++ b/stactools_browse/stactools/browse/version.py
@@ -1,2 +1,2 @@
-__version__ = '0.1.4'
+__version__ = '0.1.5'
 """Library version"""

--- a/stactools_cgls_lc100/stactools/cgls_lc100/version.py
+++ b/stactools_cgls_lc100/stactools/cgls_lc100/version.py
@@ -1,2 +1,2 @@
-__version__ = '0.1.4'
+__version__ = '0.1.5'
 """Library version"""

--- a/stactools_cli/stactools/cli/version.py
+++ b/stactools_cli/stactools/cli/version.py
@@ -1,2 +1,2 @@
-__version__ = '0.1.4'
+__version__ = '0.1.5'
 """Library version"""

--- a/stactools_core/stactools/core/version.py
+++ b/stactools_core/stactools/core/version.py
@@ -1,2 +1,2 @@
-__version__ = '0.1.4'
+__version__ = '0.1.5'
 """Library version"""

--- a/stactools_corine/stactools/corine/version.py
+++ b/stactools_corine/stactools/corine/version.py
@@ -1,2 +1,2 @@
-__version__ = '0.1.4'
+__version__ = '0.1.5'
 """Library version"""

--- a/stactools_landsat/stactools/landsat/version.py
+++ b/stactools_landsat/stactools/landsat/version.py
@@ -1,2 +1,2 @@
-__version__ = '0.1.4'
+__version__ = '0.1.5'
 """Library version"""

--- a/stactools_naip/stactools/naip/version.py
+++ b/stactools_naip/stactools/naip/version.py
@@ -1,2 +1,2 @@
-__version__ = '0.1.4'
+__version__ = '0.1.5'
 """Library version"""

--- a/stactools_planet/stactools/planet/version.py
+++ b/stactools_planet/stactools/planet/version.py
@@ -1,2 +1,2 @@
-__version__ = '0.1.4'
+__version__ = '0.1.5'
 """Library version"""

--- a/stactools_sentinel2/stactools/sentinel2/version.py
+++ b/stactools_sentinel2/stactools/sentinel2/version.py
@@ -1,2 +1,2 @@
-__version__ = '0.1.4'
+__version__ = '0.1.5'
 """Library version"""

--- a/stactools_threedep/stactools/threedep/version.py
+++ b/stactools_threedep/stactools/threedep/version.py
@@ -1,2 +1,2 @@
-__version__ = '0.1.4'
+__version__ = '0.1.5'
 """Library version"""


### PR DESCRIPTION
- Update CHANGELOG for v0.1.5
- Bump all subpackage versions to v0.1.5
- Fix minor typo in CHANGELOG

Once this PR passes CI, I'll tag it to kick off a (hopefully) successful PyPI publish. Then we can fast-forward merge this to keep the tag as an ancestor to our default branch (which isn't currently the case).