### PR TITLE
Small typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ If not using docker, itt's recommended to use [virtualenv](https://virtualenv.py
 
 - Make sure [virtualenv](https://virtualenv.pypa.io/en/latest/installation.html) is installed
 - Run `virtualenv venv`
-- Activate the virtualenv with `source venv/bin/active`
+- Activate the virtualenv with `source venv/bin/activate`
 
 #### Installing development requirements
 


### PR DESCRIPTION
Not 100% sure this is right, but I tried to copy and paste `source venv/bin/active` and it didn't work, but 'activate' did work.