### PR TITLE
Strip relative path prefix from Sentinel 2 assets.

### DIFF
--- a/stactools_sentinel2/stactools/sentinel2/safe_manifest.py
+++ b/stactools_sentinel2/stactools/sentinel2/safe_manifest.py
@@ -35,6 +35,8 @@ class SafeManifest:
         if file_path is None:
             return None
         else:
+            # Remove relative prefix that some paths have
+            file_path = file_path.strip("./")
             return os.path.join(self.granule_href, file_path)
 
     @property

--- a/tests/sentinel2/test_commands.py
+++ b/tests/sentinel2/test_commands.py
@@ -62,6 +62,10 @@ class CreateItemTest(CliTestCase):
                     bands_to_assets = defaultdict(list)
 
                     for key, asset in item.assets.items():
+                        # Ensure that there's no relative path parts
+                        # in the asset HREFs
+                        self.assertTrue('/./' not in asset.href)
+
                         self.assertTrue(is_absolute_href(asset.href))
                         bands = item.ext.eo.get_bands(asset)
                         if bands is not None:


### PR DESCRIPTION
This commit removes a '/./' that was contained in some asset hrefs for Sentinel 2 L2A items, which was caused by paths being read with a ./ prefix and joined to the base href.