### PR TITLE
Fix SR_QA_AEROSOL asset key.

### DIFF
--- a/stactools_landsat/stactools/landsat/assets.py
+++ b/stactools_landsat/stactools/landsat/assets.py
@@ -198,7 +198,7 @@ B7_ASSET_DEF = AssetDef(
     is_sr=True)
 QA_AEROSOL_ASSET_DEF = AssetDef(
     href_suffix="SR_QA_AEROSOL.TIF",
-    key="SR_B8",
+    key="SR_QA_AEROSOL",
     title="Aerosol Quality Analysis Band",
     description=("Collection 2 Level-2 Aerosol Quality Analysis Band "
                  "(ANG) Surface Reflectance"),


### PR DESCRIPTION
This fixes a typo where the SR_QA_AEROSOL had an incorrect asset key of "SR_B8"