### PR TITLE
Use both PySTAC and STAC version in version command

### DIFF
--- a/src/stactools/cli/commands/version.py
+++ b/src/stactools/cli/commands/version.py
@@ -1,5 +1,8 @@
 from click import echo
+
+import pystac
 from pystac.version import get_stac_version
+
 from stactools.core import __version__
 
 
@@ -9,6 +12,7 @@ def create_version_command(cli):
         """Display version info
         """
         echo(f"stactools version {__version__}")
-        echo(f"PySTAC version {get_stac_version()}")
+        echo(f"PySTAC version {pystac.__version__}")
+        echo(f"STAC version {get_stac_version()}")
 
     return version_command

--- a/tests/cli/commands/test_version.py
+++ b/tests/cli/commands/test_version.py
@@ -1,3 +1,4 @@
+import pystac
 from pystac.version import get_stac_version
 
 from stactools.core import __version__
@@ -15,7 +16,8 @@ class VersionTest(CliTestCase):
         result = self.run_command(['version'])
         self.assertEqual(0, result.exit_code)
         expected = (f"stactools version {__version__}\n"
-                    f"PySTAC version {get_stac_version()}\n")
+                    f"PySTAC version {pystac.__version__}\n"
+                    f"STAC version {get_stac_version()}\n")
         self.assertEqual(expected, result.output)
 
     def test_entry_point(self):


### PR DESCRIPTION
The current version command outputs the STAC version set in PySTAC to be the PySTAC version. This change outputs the PySTAC library version as well as the STAC version it supports.