### PR TITLE
Include pyproject.toml in Dockerfile's dep_builder

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,8 +14,7 @@ FROM base as dep_builder
 RUN apt-get update \
     && apt-get install -y gcc build-essential \
     && rm -rf /var/lib/apt/lists/*
-COPY setup.cfg ./
-COPY pyproject.toml ./
+COPY pyproject.toml setup.cfg ./
 COPY src/stactools/core/__init__.py src/stactools/core/
 # Install dependencies but remove the actual package
 RUN pip install --prefix=/install . \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update \
     && apt-get install -y gcc build-essential \
     && rm -rf /var/lib/apt/lists/*
 COPY setup.cfg ./
+COPY pyproject.toml ./
 COPY src/stactools/core/__init__.py src/stactools/core/
 # Install dependencies but remove the actual package
 RUN pip install --prefix=/install . \


### PR DESCRIPTION
Required with newer pip versions. See https://github.com/pypa/pip/pull/9945 for some related discussion.