### PR TITLE
Enable dependabot support for GitHub Actions, pip, and docker.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This should give us notifications for any dependencies becoming out-of-date.
This will be useful for the GitHub Actions which don't update very often and can easily grow stagnant.
I'm less sure it'll be useful for pip and docker, but I thought it was worth a try.