### PR TITLE
Change Docker image tag

### DIFF
--- a/docker/env
+++ b/docker/env
@@ -1,5 +1,5 @@
 DOCKER_REGISTRY=ghcr.io
 DOCKER_ORG=stac-utils
 DOCKER_REPO=stactools
-DOCKER_TAG=latest
-DOCKER_TAG_DEV=latest-dev
+DOCKER_TAG=local
+DOCKER_TAG_DEV=local-dev

--- a/docker/pull
+++ b/docker/pull
@@ -20,8 +20,10 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
-        docker pull $DOCKER_REGISTRY/$DOCKER_ORG/$DOCKER_REPO:$DOCKER_TAG
-        docker pull $DOCKER_REGISTRY/$DOCKER_ORG/$DOCKER_REPO:$DOCKER_TAG_DEV
+        docker pull $DOCKER_REGISTRY/$DOCKER_ORG/$DOCKER_REPO:main
+        docker tag $DOCKER_REGISTRY/$DOCKER_ORG/$DOCKER_REPO:main $DOCKER_REGISTRY/$DOCKER_ORG/$DOCKER_REPO:$DOCKER_TAG
+        docker pull $DOCKER_REGISTRY/$DOCKER_ORG/$DOCKER_REPO:main-dev
+        docker tag $DOCKER_REGISTRY/$DOCKER_ORG/$DOCKER_REPO:main-dev $DOCKER_REGISTRY/$DOCKER_ORG/$DOCKER_REPO:$DOCKER_TAG_DEV
     fi
     exit
 fi


### PR DESCRIPTION
Swap from `latest` to `local` for the Docker image tag when working with the local dev scripts.
When pulling a tag, use `main`. `latest` is the most recent release, so `main` will be closer to what most devs want.

@lossyrob After some reflection, I think I was wrong to use `latest` in #162 . I've modified the scripts to use a fully qualified name, but with a `local` (or `local-dev`) tag. It should now be fairly clear which image is being used in which scenarios. The `docker/pull` script now pulls the `main` (an image of the current `main` branch) tag and renames it `local`. This will be closer for what most devs want, since `latest` is pinned to the most recent release.

Let me know if any of that is unclear.