### PR TITLE
Add rasterio to the conda env file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,3 +4,4 @@ channels:
   - defaults
 dependencies:
   - gdal
+  - rasterio~=1.2


### PR DESCRIPTION
This should help ensure that users of conda (e.g. the Docker config) will load a version of rasterio that is built against the correct version of GDAL and won't require building it on the fly.
