### PR TITLE
Update to version 0.2.1a2

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
     defaults:
       run:
         shell: bash -l {0}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `docker/pull` script for downloading Docker images
 - GitHub issue and PR templates
+- `script/notebook` to run Jupyter notebooks ([#174](https://github.com/stac-utils/stactools/pull/174))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,24 @@
 # Changelog
 
+## stactools 0.2.1a2
+
 ### Added
 
-- Added Issue and PR Templates
+- `docker/pull` script for downloading Docker images
+- GitHub issue and PR templates
+
 ### Fixed
 
 ### Changed
+
+- Bumped `pystac` to v1.0.0
+- Restructured the Docker build
+- Using GitHub Docker Registry rather than DockerHub for storing images
+- Use both PySTAC and STAC version in version command ([#149](https://github.com/stac-utils/stactools/pull/149))
+
 ### Removed
+
+- Dropped support for Python 3.6
 
 ## stactools 0.2.1a1
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ keywords =
 classifiers =
     Development Status :: 4 - Beta
     License :: OSI Approved :: Apache Software License
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ url = https://github.com/stac-utils/stactools
 project_urls =
     Documentation = https://stactools.readthedocs.io/en/latest/
     Issues = https://github.com/stac-utils/stactools/issues
-keywords = 
+keywords =
     stactools
     pystac
     imagery
@@ -30,7 +30,7 @@ package_dir =
     = src
 packages = find_namespace:
 install_requires =
-    pystac[validation] ~= 1.0.0rc1
+    pystac[validation] ~= 1.0.0
     aiohttp ~= 3.7
     click ~= 7.1
     fsspec ~= 2021.6.0

--- a/src/stactools/core/__init__.py
+++ b/src/stactools/core/__init__.py
@@ -6,4 +6,4 @@ from stactools.core.copy import (move_asset_file_to_item, move_assets,
 from stactools.core.layout import layout_catalog
 from stactools.core.merge import (merge_items, merge_all_items)
 
-__version__ = "0.2.1a1"
+__version__ = "0.2.1a2"


### PR DESCRIPTION
Also bump pystac to 1.0.0
It drops support for Python 3.6, so dropping that.