### PR TITLE
Add script for running Jupyter notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,17 @@ A complete build and test can be run with:
 
 It is recommended to do a Docker CI build before submitting a pull request to ensure your changes will (likely) pass Github's CI.
 
+In scenarios where you want to run scripts in `docker/` but don't want to run the build, images can be downloaded via the `pull` script:
+
 ```
 > docker/pull
 ```
 
-In scenarios where you want to run scripts in `docker/` but don't want to run the build, images can be downloaded via the `pull` script.
+Run a Juypter notebook:
+
+```
+> docker/notebook
+```
 
 ### Using conda
 
@@ -187,6 +193,13 @@ or
 ```
 
 The test script also runs lint and code quality checks.
+
+Run a Juypter notebook:
+
+```
+> scripts/notebook
+```
+
 ### Documentation
 
 To build and serve the docs, all of the requirements must be installed with `scripts/update`.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ codespell
 coverage
 flake8
 ipython
+jupyter
 nbsphinx
 pylint
 sphinx

--- a/scripts/notebook
+++ b/scripts/notebook
@@ -19,7 +19,6 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     else
         jupyter notebook \
             --ip=0.0.0.0 \
-            --port=8888 \
-            --allow-root # Useful if run within the Docker containers
+            --port=8888
     fi
 fi

--- a/scripts/notebook
+++ b/scripts/notebook
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${CI}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+        "Usage: $(basename "$0")
+Launches a Jupyter notebook.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        jupyter notebook \
+            --ip=0.0.0.0 \
+            --port=8888 \
+            --allow-root # Useful if run within the Docker containers
+    fi
+fi


### PR DESCRIPTION
Before you submit a pull request, please fill in the following:

**Related Issue(s):**
#165 

**Description:**
Add a script for running Jupyter notebooks. There was already a docker script to do so.
Add Jupyter as a dev dependency.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
