### PR TITLE
use make_absolute_href when reading src catalog on copy

### DIFF
--- a/src/stactools/cli/commands/copy.py
+++ b/src/stactools/cli/commands/copy.py
@@ -1,6 +1,7 @@
 import click
 import pystac
 
+from pystac.utils import make_absolute_href
 from stactools.core.copy import copy_catalog, move_all_assets
 
 
@@ -63,7 +64,7 @@ def create_copy_command(cli):
         at DST.
 
         Note: Copying a catalog will upgrade it to the latest version of STAC."""
-        source_catalog = pystac.read_file(src)
+        source_catalog = pystac.read_file(make_absolute_href(src))
         copy_catalog(source_catalog, dst, catalog_type, copy_assets)
 
     return copy_command


### PR DESCRIPTION
This implements the quick fix described in https://github.com/stac-utils/stactools/issues/168#issuecomment-882885321