### PR TITLE
Fix CI Action when it's run on a PR in the primary repo

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -93,7 +93,7 @@ jobs:
           file: docker/Dockerfile
           target: main
           # Don't try to push if the event is a PR from a fork
-          push: ${{ github.event_name != 'pull_request' || github.head_ref.repo.full_name == github.repository }}
+          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
           tags: ${{ steps.meta-main.outputs.tags }}
           labels: ${{ steps.meta-main.outputs.labels }}
       -
@@ -115,6 +115,6 @@ jobs:
           file: docker/Dockerfile
           target: dev
           # Don't try to push if the event is a PR from a fork
-          push: ${{ github.event_name != 'pull_request' || github.head_ref.repo.full_name == github.repository }}
+          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
           tags: ${{ steps.meta-dev.outputs.tags }}
           labels: ${{ steps.meta-dev.outputs.labels }}

--- a/docker/build
+++ b/docker/build
@@ -49,5 +49,16 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         docker build $PULL $NO_CACHE --target main -t $DOCKER_REGISTRY/$DOCKER_ORG/$DOCKER_REPO:$DOCKER_TAG -f docker/Dockerfile .
         docker build $PULL $NO_CACHE --target dev -t $DOCKER_REGISTRY/$DOCKER_ORG/$DOCKER_REPO:$DOCKER_TAG_DEV -f docker/Dockerfile .
     fi
-    exit
+
+    # Wipe out the debug container if it still exists. It is now obsolete.
+    if [ "$(docker ps -aqf name=$DOCKER_DEBUG_CONTAINER_NAME)" ]; then
+        # Container exists
+        if [ "$(docker ps -qf name=$DOCKER_DEBUG_CONTAINER_NAME)" ]; then
+            # Container is runnking
+            echo "Kill debug container"
+            docker kill $DOCKER_DEBUG_CONTAINER_NAME
+        fi
+        echo "Remove debug container"
+        docker rm -f $DOCKER_DEBUG_CONTAINER_NAME
+    fi
 fi

--- a/docker/debug
+++ b/docker/debug
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${STACTOOLS_DEBUG}" ]]; then
+    set -x
+fi
+
+source $(dirname "$0")/env
+
+function usage() {
+    echo -n \
+        "Usage: $(basename "$0")
+Run a console in a docker container for debugging.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "$(docker ps -aqf name=$DOCKER_DEBUG_CONTAINER_NAME)" ]; then
+        # Container already exists
+        if [ ! "$(docker ps -qf name=$DOCKER_DEBUG_CONTAINER_NAME)" ]; then
+            # Container is stopped
+            echo "Starting debug container"
+            docker start $DOCKER_DEBUG_CONTAINER_NAME
+        fi
+        echo "Attaching debug container"
+        docker attach $DOCKER_DEBUG_CONTAINER_NAME
+    else
+        # Container doesn't exist, run it
+        echo "Running debug container"
+        docker run --name $DOCKER_DEBUG_CONTAINER_NAME -it \
+            -v `pwd`:/opt/stactools \
+            -p 8000:8000 \
+            -p 5678:5678 \
+            --entrypoint /bin/bash \
+            -e NETWORK_DEBUGGING_PORT=5678 \
+            $DOCKER_REGISTRY/$DOCKER_ORG/$DOCKER_REPO:$DOCKER_TAG_DEV
+    fi
+fi

--- a/docker/env
+++ b/docker/env
@@ -3,3 +3,4 @@ DOCKER_ORG=stac-utils
 DOCKER_REPO=stactools
 DOCKER_TAG=local
 DOCKER_TAG_DEV=local-dev
+DOCKER_DEBUG_CONTAINER_NAME=stactools-debug


### PR DESCRIPTION
PRs originating from the main repo should push PR docker images, PRs originating from forks should not.