### PR TITLE
Use fsspec for fetching external testing files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 .git/
+tests/*/data-files/external/*

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -56,6 +56,10 @@ jobs:
         run: conda env update -f environment.yml -n test
       - name: Execute linters and test suites
         run: ./scripts/cibuild
+      - name: Install with extra_requires
+        run: pip install -e '.[all]'
+      - name: Test again
+        run: ./scripts/test
   docker:
     name: docker
     needs:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Execute linters and test suites
         run: ./scripts/cibuild
       - name: Install with extra_requires
-        run: pip install -e '.[all]'
+        run: pip install -e '.[s3]'
       - name: Test again
         run: ./scripts/test
   docker:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Execute linters and test suites
         run: ./scripts/cibuild
       - name: Install with extra_requires
-        run: pip install -e '.[s3]'
+        run: pip install -e '.[all]'
       - name: Test again
         run: ./scripts/test
   docker:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# External testing files
+tests/*/data-files/external/*
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Optional dependency on s3fs ([#178](https://github.com/stac-utils/stactools/pull/178)), enabling:
   - Using s3 files as external data for testing
-  - Using s3 hrefs with stactools functionality by installing with `pip install stactools[s3]` (or `pip install stactools[all]`)
+  - Using s3 hrefs with stactools functionality by installing with `pip install stactools[s3]`
 
 ## stactools 0.2.1a2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Optional dependency on s3fs ([#178](https://github.com/stac-utils/stactools/pull/178)), enabling:
   - Using s3 files as external data for testing
-  - Using s3 hrefs with stactools functionality by installing with `pip install stactools[s3]`
+  - Using s3 hrefs with stactools functionality by installing with `pip install stactools[s3]` (or `pip install stactools[all]`)
 
 ## stactools 0.2.1a2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Optional dependency on s3fs ([#178](https://github.com/stac-utils/stactools/pull/178)), enabling:
+  - Using s3 files as external data for testing
+  - Using s3 hrefs with stactools functionality by installing with `pip install stactools[s3]` (or `pip install stactools[all]`)
+
 ## stactools 0.2.1a2
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -32,6 +32,23 @@ From source repository:
 > pip install .
 ```
 
+### Optional dependencies
+
+`stactools` includes some optional dependencies:
+- `s3`: Enables s3 hrefs via `fsspec` and `s3fs`
+
+To install a single optional dependency:
+
+```bash
+> pip install stactools[s3]
+```
+
+To install all optional dependencies:
+
+```bash
+> pip install stactools[all]
+```
+
 ### Docker
 
 To download the Docker image from the registry:

--- a/README.md
+++ b/README.md
@@ -37,11 +37,18 @@ From source repository:
 `stactools` includes some optional dependencies:
 - `s3`: Enables s3 hrefs via `fsspec` and `s3fs`
 
-To install a single optional dependency, e.g. `s3`:
+To install a single optional dependency:
 
 ```bash
 > pip install stactools[s3]
 ```
+
+To install all optional dependencies:
+
+```bash
+> pip install stactools[all]
+```
+
 ### Docker
 
 To download the Docker image from the registry:

--- a/README.md
+++ b/README.md
@@ -37,18 +37,11 @@ From source repository:
 `stactools` includes some optional dependencies:
 - `s3`: Enables s3 hrefs via `fsspec` and `s3fs`
 
-To install a single optional dependency:
+To install a single optional dependency, e.g. `s3`:
 
 ```bash
 > pip install stactools[s3]
 ```
-
-To install all optional dependencies:
-
-```bash
-> pip install stactools[all]
-```
-
 ### Docker
 
 To download the Docker image from the registry:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update \
 COPY pyproject.toml setup.cfg ./
 COPY src/stactools/core/__init__.py src/stactools/core/
 # Install dependencies but remove the actual package
-RUN pip install --prefix=/install . \
+RUN pip install --prefix=/install .[all] \
     && rm -r /install/lib/*/site-packages/stactools*
 
 
@@ -31,11 +31,11 @@ RUN conda install -c conda-forge pandoc && conda clean -af
 COPY requirements-dev.txt ./
 RUN pip install -r requirements-dev.txt
 COPY . ./
-RUN pip install -e .
+RUN pip install -e .[all]
 
 
 FROM base AS main
 COPY --from=dep_builder /install /opt/conda
 COPY src ./src
 COPY pyproject.toml setup.cfg ./
-RUN pip install .
+RUN pip install .[all]

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,8 +40,10 @@ install_requires =
     lxml ~= 4.6
 
 [options.extras_require]
-all = s3
-s3 = s3fs ~= 2021.7
+all =
+    %(s3)s
+s3 =
+    s3fs ~= 2021.7
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,6 @@ install_requires =
     lxml ~= 4.6
 
 [options.extras_require]
-all = s3
 s3 = s3fs ~= 2021.7
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,12 +32,16 @@ install_requires =
     pystac[validation] ~= 1.0.0
     aiohttp ~= 3.7
     click ~= 7.1
-    fsspec ~= 2021.6.0
+    fsspec ~= 2021.7
     requests ~= 2.25
     Shapely ~= 1.7
     pyproj ~= 3.0
     rasterio ~= 1.2
     lxml ~= 4.6
+
+[options.extras_require]
+all = s3
+s3 = s3fs ~= 2021.7
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
     lxml ~= 4.6
 
 [options.extras_require]
+all = s3
 s3 = s3fs ~= 2021.7
 
 [options.packages.find]

--- a/src/stactools/testing/test_data.py
+++ b/src/stactools/testing/test_data.py
@@ -46,9 +46,25 @@ class TestData:
             print('Downloading external test data {}...'.format(rel_path))
             os.makedirs(os.path.dirname(path), exist_ok=True)
 
-            with fsspec.open(entry["url"]) as f:
-                data = f.read()
-            if entry['compress'] == 'zip':
+            s3_config = entry.get("s3")
+            if s3_config:
+                try:
+                    import s3fs
+                except ImportError as e:
+                    print(
+                        "Trying to download external test data via s3, "
+                        "but s3fs is not installed and the download requires "
+                        "configuring the s3fs filesystem. Install stactools "
+                        "with s3fs via `pip install stactools[s3]` and try again."
+                    )
+                    raise (e)
+                s3 = s3fs.S3FileSystem(**s3_config)
+                with s3.open(entry["url"]) as f:
+                    data = f.read()
+            else:
+                with fsspec.open(entry["url"]) as f:
+                    data = f.read()
+            if entry.get("compress") == 'zip':
                 with TemporaryDirectory() as tmp_dir:
                     tmp_path = os.path.join(tmp_dir, 'file.zip')
                     with open(tmp_path, 'wb') as f:

--- a/src/stactools/testing/test_data.py
+++ b/src/stactools/testing/test_data.py
@@ -3,7 +3,7 @@ import shutil
 from tempfile import TemporaryDirectory
 from zipfile import ZipFile
 
-import requests
+import fsspec
 
 # example external data:
 # {
@@ -46,18 +46,19 @@ class TestData:
             print('Downloading external test data {}...'.format(rel_path))
             os.makedirs(os.path.dirname(path), exist_ok=True)
 
-            resp = requests.get(entry['url'])
+            with fsspec.open(entry["url"]) as f:
+                data = f.read()
             if entry['compress'] == 'zip':
                 with TemporaryDirectory() as tmp_dir:
                     tmp_path = os.path.join(tmp_dir, 'file.zip')
                     with open(tmp_path, 'wb') as f:
-                        f.write(resp.content)
+                        f.write(data)
                     z = ZipFile(tmp_path)
                     name = z.namelist()[0]
                     extracted_path = z.extract(name)
                     shutil.move(extracted_path, path)
             else:
                 with open(path, 'wb') as f:
-                    f.write(resp.content)
+                    f.write(data)
 
         return path

--- a/tests/testing/__init__.py
+++ b/tests/testing/__init__.py
@@ -9,6 +9,14 @@ test_data = TestData(
         },
         "goes-16/index.html": {
             "url": "s3://noaa-goes16/index.html",
-            "compress": False
+        },
+        "AW3D30_global.vrt": {
+            "url": "s3://raster/AW3D30/AW3D30_global.vrt",
+            "s3": {
+                "anon": True,
+                "client_kwargs": {
+                    "endpoint_url": "https://opentopography.s3.sdsc.edu"
+                }
+            }
         }
     })

--- a/tests/testing/__init__.py
+++ b/tests/testing/__init__.py
@@ -7,9 +7,6 @@ test_data = TestData(
             "stac-spec/v1.0.0/examples/simple-item.json",
             "compress": False,
         },
-        "goes-16/index.html": {
-            "url": "s3://noaa-goes16/index.html",
-        },
         "AW3D30_global.vrt": {
             "url": "s3://raster/AW3D30/AW3D30_global.vrt",
             "s3": {

--- a/tests/testing/__init__.py
+++ b/tests/testing/__init__.py
@@ -1,0 +1,14 @@
+from stactools.testing import TestData
+
+test_data = TestData(
+    __file__, {
+        "item.json": {
+            "url": "https://raw.githubusercontent.com/radiantearth/"
+            "stac-spec/v1.0.0/examples/simple-item.json",
+            "compress": False,
+        },
+        "goes-16/index.html": {
+            "url": "s3://noaa-goes16/index.html",
+            "compress": False
+        }
+    })

--- a/tests/testing/test_test_data.py
+++ b/tests/testing/test_test_data.py
@@ -13,16 +13,29 @@ class TestDataTest(TestCase):
         self.assertEqual(item.id, "20201211_223832_CS2")
 
     def test_external_data_s3(self):
-        try:
-            import s3fs  # noqa
-        except ImportError:
-            raise SkipTest(
-                "Skipping testing external data with s3 because s3fs is not installed"
-            )
+        skip_without_s3fs()
         path = test_data.get_external_data("goes-16/index.html")
         with open(path) as f:
             html = f.read()
         self.assertNotEqual(
             html.find("Amazon"), -1,
             "Could not find 'Amazon' in the index page for the AWS public dataset"
+        )
+
+    def test_external_data_s3_with_config(self):
+        skip_without_s3fs()
+        path = test_data.get_external_data("AW3D30_global.vrt")
+        with open(path) as f:
+            xml = f.read()
+        self.assertNotEqual(
+            xml.find("ALPSMLC30_N041W106_DSM"), -1,
+            "Could not find 'ALPSMLC30_N041W106_DSM' in the ALOS VRT")
+
+
+def skip_without_s3fs():
+    try:
+        import s3fs  # noqa
+    except ImportError:
+        raise SkipTest(
+            "Skipping testing external data with s3 because s3fs is not installed"
         )

--- a/tests/testing/test_test_data.py
+++ b/tests/testing/test_test_data.py
@@ -1,0 +1,28 @@
+from unittest import TestCase, SkipTest
+
+import pystac
+
+from tests.testing import test_data
+
+
+class TestDataTest(TestCase):
+    """Say test ONE MORE TIME and I swear..."""
+    def test_external_data_https(self):
+        path = test_data.get_external_data("item.json")
+        item = pystac.read_file(path)
+        self.assertEqual(item.id, "20201211_223832_CS2")
+
+    def test_external_data_s3(self):
+        try:
+            import s3fs  # noqa
+        except ImportError:
+            raise SkipTest(
+                "Skipping testing external data with s3 because s3fs is not installed"
+            )
+        path = test_data.get_external_data("goes-16/index.html")
+        with open(path) as f:
+            html = f.read()
+        self.assertNotEqual(
+            html.find("Amazon"), -1,
+            "Could not find 'Amazon' in the index page for the AWS public dataset"
+        )

--- a/tests/testing/test_test_data.py
+++ b/tests/testing/test_test_data.py
@@ -14,16 +14,6 @@ class TestDataTest(TestCase):
 
     def test_external_data_s3(self):
         skip_without_s3fs()
-        path = test_data.get_external_data("goes-16/index.html")
-        with open(path) as f:
-            html = f.read()
-        self.assertNotEqual(
-            html.find("Amazon"), -1,
-            "Could not find 'Amazon' in the index page for the AWS public dataset"
-        )
-
-    def test_external_data_s3_with_config(self):
-        skip_without_s3fs()
         path = test_data.get_external_data("AW3D30_global.vrt")
         with open(path) as f:
             xml = f.read()


### PR DESCRIPTION
**Related Issue(s):** n/a

**Description:** This enables external files stored on all of the systems supported by fsspec.

Also includes:
- Two `extra_requires` options. `stactools[s3]` installs `s3fs`, which is required to use fsspec on s3 hrefs. `stactools[all]` includes `s3` and any future extra_requires.
- CI tests for `stactools[all]`, to make sure we are testing both with and without `extra_requires`.
- Version bump for `fssepc`.
- Unit tests for `stactools.testing`, which leads to saying "test" a lot :-).
- README instructions for install w/ optional dependencies.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
