### PR TITLE
Remove pystac from the mypy ignore list

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -9,11 +9,6 @@ ignore_missing_imports = True
 [mypy-lxml.*]
 ignore_missing_imports = True
 
-# When the following PR is merged, drop the pystac block
-# https://github.com/stac-utils/pystac/pull/579
-[mypy-pystac.*]
-ignore_missing_imports = True
-
 [mypy-rasterio.*]
 ignore_missing_imports = True
 

--- a/scripts/lint
+++ b/scripts/lint
@@ -24,12 +24,6 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         # Lint
         flake8 ${DIRS_TO_CHECK[@]}
         # Type checking
-        for module in src/*/; do
-            if [[ "$module" == *.egg-info/ ]] ; then continue; fi
-            for submodule in "$module"/*; do
-                mypy -p "$(basename "$module").$(basename "$submodule")"
-            done
-        done
-
+        mypy src
     fi
 fi


### PR DESCRIPTION
Now that https://github.com/stac-utils/pystac/pull/579 has been merged, `pystac` is publishing type information.
Remove `pystac` from the list of modules ignored by `mpyp`.
Also simplify the lint command of `mypy` thanks to the new config in `mypy.ini`.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [ ] ~Documentation has been updated to reflect changes, if applicable.~
- [ ] ~Changes are added to the [CHANGELOG](../CHANGELOG.md).~ (`mypy` is already in thre
