### PR TITLE
Add type annotations

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -2,11 +2,22 @@
 mypy_path = src
 explicit_package_bases = True
 namespace_packages = True
+check_untyped_defs = True
+disallow_any_generics = True
+disallow_incomplete_defs = True
+disallow_subclassing_any = True
+disallow_untyped_calls = True
+disallow_untyped_decorators = False
+disallow_untyped_defs = True
+no_implicit_optional = True
+show_error_codes = True
+strict_equality = True
+warn_redundant_casts = True
+warn_return_any = True
+warn_unused_configs = True
+warn_unused_ignores = True
 
 [mypy-fsspec.*]
-ignore_missing_imports = True
-
-[mypy-lxml.*]
 ignore_missing_imports = True
 
 [mypy-rasterio.*]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ coverage
 flake8
 ipython
 jupyter
+lxml-stubs
 mypy
 nbsphinx
 pylint

--- a/src/stactools/cli/__init__.py
+++ b/src/stactools/cli/__init__.py
@@ -5,7 +5,7 @@ import stactools.core
 stactools.core.use_fsspec()
 
 
-def register_plugin(registry):
+def register_plugin(registry: 'Registry') -> None:
     # Register subcommands
 
     from stactools.cli.commands import (copy, info, layout, merge, migrate,

--- a/src/stactools/cli/cli.py
+++ b/src/stactools/cli/cli.py
@@ -1,11 +1,11 @@
 import logging
-
 import click
 
+from typing import Union
 from stactools.cli import registry
 
 
-def setup_logging(level):
+def setup_logging(level: Union[str, int]) -> None:
     logger = logging.getLogger('stactools')
     logger.setLevel(level)
 
@@ -23,7 +23,7 @@ def setup_logging(level):
               '--quiet',
               help=("Use quiet mode (no output)"),
               is_flag=True)
-def cli(verbose, quiet):
+def cli(verbose: bool, quiet: bool) -> None:
     logging_level = logging.INFO
     if verbose:
         logging_level = logging.DEBUG
@@ -36,7 +36,7 @@ for create_subcommand in registry.get_create_subcommand_functions():
     create_subcommand(cli)
 
 
-def run_cli():
+def run_cli() -> None:
     cli(prog_name='stac')
 
 

--- a/src/stactools/cli/commands/info.py
+++ b/src/stactools/cli/commands/info.py
@@ -2,11 +2,14 @@ import click
 import pystac
 
 
-def print_info(catalog_path):
+def print_info(catalog_path: str) -> None:
     cat_count, col_count, item_count = 0, 0, 0
     cat_ext, col_ext, item_ext = set([]), set([]), set([])
 
     cat = pystac.read_file(catalog_path)
+    if not isinstance(cat, pystac.Catalog):
+        print("{} is not a catalog".format(catalog_path))
+        return
 
     for root, _, items in cat.walk():
         if root.STAC_OBJECT_TYPE == pystac.STACObjectType.COLLECTION:
@@ -41,17 +44,17 @@ def print_info(catalog_path):
     print('      ITEMS: {} {}'.format(item_count, item_ext_info))
 
 
-def create_info_command(cli):
+def create_info_command(cli: click.Group) -> click.Command:
     @cli.command('info',
                  short_help='Display info about a static STAC catalog.')
     @click.argument('catalog_path')
-    def info_command(catalog_path):
+    def info_command(catalog_path: str) -> None:
         print_info(catalog_path)
 
     return info_command
 
 
-def create_describe_command(cli):
+def create_describe_command(cli: click.Group) -> click.Command:
     @cli.command(
         'describe',
         short_help='Prints out a list of all catalogs, collections and items '
@@ -61,8 +64,11 @@ def create_describe_command(cli):
                   '--include-hrefs',
                   is_flag=True,
                   help='Include HREFs in description.')
-    def describe_command(catalog_path, include_hrefs):
+    def describe_command(catalog_path: str, include_hrefs: bool) -> None:
         cat = pystac.read_file(catalog_path)
+        if not isinstance(cat, pystac.Catalog):
+            print("{} is not a catalog".format(catalog_path))
+            return
         cat.describe(include_hrefs=include_hrefs)
 
     return describe_command

--- a/src/stactools/cli/commands/layout.py
+++ b/src/stactools/cli/commands/layout.py
@@ -4,7 +4,7 @@ import pystac
 from stactools.core import layout_catalog
 
 
-def create_layout_command(cli):
+def create_layout_command(cli: click.Group) -> click.Command:
     @cli.command(
         'layout',
         short_help='Reformat the layout of a STAC based on templating.')
@@ -28,9 +28,13 @@ def create_layout_command(cli):
                   '--move-assets',
                   is_flag=True,
                   help='Move assets to the target catalog Item locations.')
-    def layout_command(catalog, item_path_template, create_subcatalogs,
-                       remove_existing_subcatalogs, move_assets):
+    def layout_command(catalog: str, item_path_template: str,
+                       create_subcatalogs: bool,
+                       remove_existing_subcatalogs: bool,
+                       move_assets: bool) -> None:
         source = pystac.read_file(catalog)
+        if not isinstance(source, pystac.Catalog):
+            raise click.BadArgumentUsage(f"{catalog} is not a STAC Catalog")
 
         layout_catalog(source,
                        item_path_template,

--- a/src/stactools/cli/commands/merge.py
+++ b/src/stactools/cli/commands/merge.py
@@ -1,34 +1,40 @@
 import click
 import pystac
 
+from typing import Optional
 from stactools.core import merge_all_items
 
 
-def merge(source_catalog,
-          target_catalog,
-          collection_id=None,
-          move_assets=False,
-          ignore_conflicts=False,
-          as_child=False,
-          child_folder=None):
+def merge(source_catalog: str,
+          target_catalog: str,
+          collection_id: Optional[str] = None,
+          move_assets: bool = False,
+          ignore_conflicts: bool = False,
+          as_child: bool = False,
+          child_folder: Optional[str] = None) -> None:
     source = pystac.read_file(source_catalog)
+    if not isinstance(source, pystac.Catalog):
+        raise click.BadArgumentUsage(f"{source_catalog} is not a STAC Catalog")
+
     target = pystac.read_file(target_catalog)
+    if not isinstance(target, pystac.Catalog):
+        raise click.BadArgumentUsage(f"{target_catalog} is not a STAC Catalog")
 
     if collection_id is not None:
-        target = target.get_child(collection_id, recursive=True)
-        if target is None:
+        target_new = target.get_child(collection_id, recursive=True)
+        if target_new is None:
             raise click.BadOptionUsage(
                 'collection',
                 'A collection with ID {} does not exist in {}'.format(
                     collection_id, target_catalog))
-
+        target = target_new
     merge_all_items(source, target, move_assets, ignore_conflicts, as_child,
                     child_folder)
 
     target.save()
 
 
-def create_merge_command(cli):
+def create_merge_command(cli: click.Group) -> click.Command:
     @cli.command('merge', short_help='Merge items from one STAC into another.')
     @click.argument('source_catalog')
     @click.argument('target_catalog')
@@ -55,8 +61,10 @@ def create_merge_command(cli):
                   help=('The subfolder name to copy to if the option to merge '
                         'as a child is used. If not provided, the catalog id '
                         'will be used'))
-    def merge_command(source_catalog, target_catalog, collection, move_assets,
-                      ignore_conflicts, as_child, child_folder):
+    def merge_command(source_catalog: str, target_catalog: str,
+                      collection: str, move_assets: bool,
+                      ignore_conflicts: bool, as_child: bool,
+                      child_folder: str) -> None:
         merge(source_catalog,
               target_catalog,
               collection_id=collection,

--- a/src/stactools/cli/commands/migrate.py
+++ b/src/stactools/cli/commands/migrate.py
@@ -1,15 +1,15 @@
 import click
 
 
-def migrate(option):
+def migrate(option: click.Option) -> None:
     # TODO
     print(option)
 
 
-def create_migrate_command(cli):
+def create_migrate_command(cli: click.Group) -> click.Command:
     @cli.command('migrate', short_help='Migrate a STAC catalog (TODO)')
     @click.option('--option', '-o', default=1, help='A test option')
-    def migrate_command(option):
+    def migrate_command(option: click.Option) -> None:
         migrate(option)
 
     return migrate_command

--- a/src/stactools/cli/commands/validate.py
+++ b/src/stactools/cli/commands/validate.py
@@ -3,13 +3,12 @@ from typing import Optional, List
 
 import click
 import pystac
-from pystac import Item, Collection, STACValidationError, STACObject
-from pystac.catalog import Catalog
 
+from pystac import Catalog, Collection, Item, STACObject, STACValidationError
 from stactools.core.utils import href_exists
 
 
-def create_validate_command(cli):
+def create_validate_command(cli: click.Group) -> click.Command:
     @cli.command("validate", short_help="Validate a stac object.")
     @click.argument("href")
     @click.option("--recurse/--no-recurse",
@@ -23,7 +22,8 @@ def create_validate_command(cli):
         "--assets/--no-assets",
         default=True,
         help=("If false, do not check any of the collection's/item's assets."))
-    def validate_command(href, recurse, links, assets):
+    def validate_command(href: str, recurse: bool, links: bool,
+                         assets: bool) -> None:
         """Validates a STAC object.
 
         Prints any validation errors to stdout.

--- a/src/stactools/cli/commands/version.py
+++ b/src/stactools/cli/commands/version.py
@@ -4,11 +4,12 @@ import pystac
 from pystac.version import get_stac_version
 
 from stactools.core import __version__
+from click.core import Command, Group
 
 
-def create_version_command(cli):
+def create_version_command(cli: Group) -> Command:
     @cli.command('version', short_help='Display version info.')
-    def version_command():
+    def version_command() -> None:
         """Display version info
         """
         echo(f"stactools version {__version__}")

--- a/src/stactools/cli/registry.py
+++ b/src/stactools/cli/registry.py
@@ -1,15 +1,23 @@
+from pkgutil import ModuleInfo
+from types import ModuleType
+from typing import Callable, Iterator, List
+from click import Command, Group
+
+
 class Registry():
     """A registry for resources that are built-in or contributed by plugins."""
-    def __init__(self):
-        self._create_command_functions = []
+    def __init__(self) -> None:
+        self._create_command_functions: List[Callable[[Group], Command]] = []
 
-    def register_subcommand(self, create_command_function):
+    def register_subcommand(
+            self, create_command_function: Callable[[Group], Command]) -> None:
         self._create_command_functions.append(create_command_function)
 
-    def get_create_subcommand_functions(self):
+    def get_create_subcommand_functions(
+            self) -> List[Callable[[Group], Command]]:
         return self._create_command_functions[:]
 
-    def load_plugins(self):
+    def load_plugins(self) -> None:
         """Discover all plugins and register their resources.
         Import each Python module within the stactools namespace package
         and call the register_plugin function at its root (if it exists).
@@ -19,12 +27,14 @@ class Registry():
         import stactools
 
         # From https://packaging.python.org/guides/creating-and-discovering-plugins/#using-namespace-packages  # noqa
-        def iter_namespace(ns_pkg):
+        def iter_namespace(ns_pkg: ModuleType) -> Iterator[ModuleInfo]:
             # Specifying the second argument (prefix) to iter_modules makes the
             # returned name an absolute name instead of a relative one. This allows
             # import_module to work without having to do additional modification to
             # the name.
-            return pkgutil.iter_modules(ns_pkg.__path__, ns_pkg.__name__ + '.')
+            return pkgutil.iter_modules(
+                ns_pkg.__path__,  # type: ignore  # mypy issue #1422
+                ns_pkg.__name__ + '.')
 
         discovered_plugins = {
             name: importlib.import_module(name)

--- a/src/stactools/core/io/__init__.py
+++ b/src/stactools/core/io/__init__.py
@@ -22,13 +22,13 @@ def read_text(href: str,
 class FsspecStacIO(DefaultStacIO):
     def read_text_from_href(self, href: str, *args: Any, **kwargs: Any) -> str:
         with fsspec.open(href, "r") as f:
-            return f.read()
+            return str(f.read())
 
     def write_text_from_href(self, href: str, txt: str, *args: Any,
                              **kwargs: Any) -> None:
         with fsspec.open(href, "w") as destination:
-            return destination.write(txt)
+            destination.write(txt)
 
 
-def use_fsspec():
+def use_fsspec() -> None:
     StacIO.set_default(FsspecStacIO)

--- a/src/stactools/core/io/__init__.py
+++ b/src/stactools/core/io/__init__.py
@@ -22,7 +22,14 @@ def read_text(href: str,
 class FsspecStacIO(DefaultStacIO):
     def read_text_from_href(self, href: str, *args: Any, **kwargs: Any) -> str:
         with fsspec.open(href, "r") as f:
-            return str(f.read())
+            s = f.read()
+            if isinstance(s, str):
+                return s
+            elif isinstance(s, bytes):
+                return str(s, encoding='utf-8')
+            else:
+                raise ValueError(
+                    f"Unable to decode data loaded from HREF: {href}")
 
     def write_text_from_href(self, href: str, txt: str, *args: Any,
                              **kwargs: Any) -> None:

--- a/src/stactools/core/io/xml.py
+++ b/src/stactools/core/io/xml.py
@@ -53,7 +53,13 @@ class XmlElement:
 
     @property
     def text(self) -> Optional[str]:
-        return str(self.element.text)
+        if isinstance(self.element.text, str):
+            return self.element.text
+        elif isinstance(self.element.text, bytes):
+            return str(self.element.text, encoding='utf-8')
+        else:
+            assert self.element.text is None
+            return None
 
     @lru_cache(maxsize=100)
     def get_attr(self, attr: str) -> Optional[str]:

--- a/src/stactools/core/io/xml.py
+++ b/src/stactools/core/io/xml.py
@@ -16,7 +16,7 @@ class XmlElement:
 
     @lru_cache(maxsize=100)
     def find(self, xpath: str) -> Optional["XmlElement"]:
-        node = self.element.find(xpath, self.element.nsmap)
+        node = self.element.find(xpath, self.element.nsmap)  # type: ignore
         return None if node is None else XmlElement(node)
 
     def find_or_throw(
@@ -30,8 +30,8 @@ class XmlElement:
     @lru_cache(maxsize=100)
     def findall(self, xpath: str) -> List["XmlElement"]:
         return [
-            XmlElement(e)
-            for e in self.element.findall(xpath, self.element.nsmap)
+            XmlElement(e) for e in self.element.findall(
+                xpath, self.element.nsmap)  # type: ignore
         ]
 
     @lru_cache(maxsize=100)
@@ -52,8 +52,8 @@ class XmlElement:
         return None if node is None else node.get_attr(attr)
 
     @property
-    def text(self):
-        return self.element.text
+    def text(self) -> Optional[str]:
+        return str(self.element.text)
 
     @lru_cache(maxsize=100)
     def get_attr(self, attr: str) -> Optional[str]:

--- a/src/stactools/core/layout.py
+++ b/src/stactools/core/layout.py
@@ -1,15 +1,16 @@
 import os
 
+from pystac import Catalog
 from pystac.layout import TemplateLayoutStrategy
 
 from stactools.core import move_all_assets
 
 
-def layout_catalog(catalog,
-                   item_path_template,
-                   create_subcatalogs=False,
-                   remove_existing_subcatalogs=False,
-                   move_assets=False):
+def layout_catalog(catalog: Catalog,
+                   item_path_template: str,
+                   create_subcatalogs: bool = False,
+                   remove_existing_subcatalogs: bool = False,
+                   move_assets: bool = False) -> Catalog:
     """Modify the layout of a STAC.
 
     Given a catalog and a layout template, modify the layout of the STAC
@@ -39,17 +40,19 @@ def layout_catalog(catalog,
     if remove_existing_subcatalogs:
         items = catalog.get_all_items()
         for item in items:
-            item.get_parent().remove_item(item.id)
+            parent = item.get_parent()
+            assert parent is not None
+            parent.remove_item(item.id)
             catalog.add_item(item)
 
         catalog.clear_children()
 
     if create_subcatalogs:
         catalog.generate_subcatalogs(template=item_path_template)
-        catalog.normalize_hrefs(os.path.dirname(catalog.get_self_href()))
+        catalog.normalize_hrefs(os.path.dirname(catalog.self_href))
     else:
         strategy = TemplateLayoutStrategy(item_template=item_path_template)
-        catalog.normalize_hrefs(os.path.dirname(catalog.get_self_href()),
+        catalog.normalize_hrefs(os.path.dirname(catalog.self_href),
                                 strategy=strategy)
 
     if move_assets:

--- a/src/stactools/core/merge.py
+++ b/src/stactools/core/merge.py
@@ -1,6 +1,7 @@
 import os
 
 import pystac
+from typing import Optional
 from pystac.layout import BestPracticesLayoutStrategy
 from pystac.utils import (is_absolute_href, make_relative_href)
 from shapely.geometry import shape, mapping
@@ -9,10 +10,10 @@ from stactools.core.copy import (move_asset_file_to_item, copy_catalog,
                                  move_assets as do_move_assets)
 
 
-def merge_items(source_item,
-                target_item,
-                move_assets=False,
-                ignore_conflicts=False):
+def merge_items(source_item: pystac.Item,
+                target_item: pystac.Item,
+                move_assets: bool = False,
+                ignore_conflicts: bool = False) -> None:
     """Merges the assets from source_item into target_item.
 
     The geometry and bounding box of the items will also be merged.
@@ -28,6 +29,9 @@ def merge_items(source_item,
             will not be moved. If False, either of these situations will throw an error.
     """
     target_item_href = target_item.get_self_href()
+    if target_item_href is None:
+        raise ValueError(
+            f"Target Item {target_item.id} must have an HREF for merge")
     for key, asset in source_item.assets.items():
         if key in target_item.assets:
             if ignore_conflicts:
@@ -38,12 +42,14 @@ def merge_items(source_item,
                     'cannot merge asset in from {}'.format(
                         target_item, key, source_item))
         else:
+            asset_href = asset.get_absolute_href()
+            if asset_href is None:
+                raise ValueError(
+                    f"Asset {asset.title} must have an HREF for merge")
             if move_assets:
-                asset_href = asset.get_absolute_href()
                 new_asset_href = move_asset_file_to_item(
                     target_item, asset_href, ignore_conflicts=ignore_conflicts)
             else:
-                asset_href = asset.get_absolute_href()
                 if not is_absolute_href(asset.href):
                     asset_href = make_relative_href(asset_href,
                                                     target_item_href)
@@ -59,12 +65,12 @@ def merge_items(source_item,
     target_item.bbox = list(union_geom.bounds)
 
 
-def merge_all_items(source_catalog,
-                    target_catalog,
-                    move_assets=False,
-                    ignore_conflicts=False,
-                    as_child=False,
-                    child_folder=None):
+def merge_all_items(source_catalog: pystac.Catalog,
+                    target_catalog: pystac.Catalog,
+                    move_assets: bool = False,
+                    ignore_conflicts: bool = False,
+                    as_child: bool = False,
+                    child_folder: Optional[str] = None) -> pystac.Catalog:
     """Merge all items from source_catalog into target_catalog.
 
     Calls merge_items on any items that have the same ID between the two catalogs.
@@ -94,14 +100,18 @@ def merge_all_items(source_catalog,
     source_items = source_catalog.get_all_items()
     ids_to_items = {item.id: item for item in source_items}
 
-    parent_dir = os.path.dirname(target_catalog.get_self_href())
+    parent_dir = os.path.dirname(target_catalog.self_href)
     if as_child:
         child_dir = os.path.join(parent_dir, child_folder or source_catalog.id)
         copy_catalog(source_catalog, child_dir, source_catalog.catalog_type,
                      move_assets)
         child_catalog_path = os.path.join(
-            child_dir, os.path.basename(source_catalog.get_self_href()))
-        source_catalog = pystac.read_file(child_catalog_path)
+            child_dir, os.path.basename(source_catalog.self_href))
+        new_source_catalog = pystac.read_file(child_catalog_path)
+        if not isinstance(new_source_catalog, pystac.Catalog):
+            raise ValueError(
+                f"Child catalog {child_catalog_path} is not a STAC Catalog")
+        source_catalog = new_source_catalog
         target_catalog.add_child(source_catalog, source_catalog.title)
     else:
         for item in target_catalog.get_all_items():
@@ -129,7 +139,7 @@ def merge_all_items(source_catalog,
             if move_assets:
                 do_move_assets(item_copy, copy=False)
 
-    if target_catalog.STAC_OBJECT_TYPE == pystac.STACObjectType.COLLECTION:
+    if isinstance(target_catalog, pystac.Collection):
         target_catalog.update_extent_from_items()
 
     return target_catalog

--- a/src/stactools/core/projection.py
+++ b/src/stactools/core/projection.py
@@ -7,7 +7,7 @@ import rasterio.crs
 import rasterio.transform
 
 
-def epsg_from_utm_zone_number(utm_zone_number, south):
+def epsg_from_utm_zone_number(utm_zone_number: int, south: bool) -> int:
     """Return the EPSG code for a UTM zone number.
 
     Args:
@@ -27,9 +27,9 @@ def epsg_from_utm_zone_number(utm_zone_number, south):
 
 
 def reproject_geom(src_crs: Union[pyproj.CRS, rasterio.crs.CRS, str],
-                   dest_crs: Any,
+                   dest_crs: Union[pyproj.CRS, rasterio.crs.CRS, str],
                    geom: Dict[str, Any],
-                   precision: Optional[int] = None):
+                   precision: Optional[int] = None) -> Dict[str, Any]:
     """Reprojects a geometry represented as GeoJSON
     from the src_crs to the dest crs.
 
@@ -49,7 +49,7 @@ def reproject_geom(src_crs: Union[pyproj.CRS, rasterio.crs.CRS, str],
                                               always_xy=True)
     result = deepcopy(geom)
 
-    def fn(coords):
+    def fn(coords: abc.Sequence[Any]) -> abc.Sequence[Any]:
         coords = list(coords)
         for i in range(0, len(coords)):
             coord = coords[i]

--- a/src/stactools/core/utils/__init__.py
+++ b/src/stactools/core/utils/__init__.py
@@ -20,4 +20,4 @@ def href_exists(href: str) -> bool:
     https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.exists.
     """
     fs, _, paths = fsspec.get_fs_token_paths(href)
-    return paths and fs.exists(paths[0])
+    return bool(paths and fs.exists(paths[0]))

--- a/src/stactools/core/utils/convert.py
+++ b/src/stactools/core/utils/convert.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from stactools.core.utils.subprocess import call
 
@@ -7,8 +7,8 @@ DEFAULT_COGIFY_ARGS = ["-co", "compress=deflate"]
 
 def cogify(infile: str,
            outfile: str,
-           args: List[str] = None,
-           extra_args: List[str] = None):
+           args: Optional[List[str]] = None,
+           extra_args: Optional[List[str]] = None) -> int:
     """Creates a COG from a GDAL-readable file."""
     if args is None:
         args = DEFAULT_COGIFY_ARGS[:]

--- a/src/stactools/core/utils/subprocess.py
+++ b/src/stactools/core/utils/subprocess.py
@@ -1,12 +1,12 @@
 import logging
 from subprocess import Popen, PIPE, STDOUT
-from typing import List
+from typing import IO, List
 
 logger = logging.getLogger(__name__)
 
 
 def call(command: List[str]) -> int:
-    def log_subprocess_output(pipe):
+    def log_subprocess_output(pipe: IO[bytes]) -> None:
         for line in iter(pipe.readline, b''):  # b'\n'-separated lines
             logger.info(line.decode("utf-8").strip('\n'))
 

--- a/src/stactools/testing/cli.py
+++ b/src/stactools/testing/cli.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 @click.group()
-def cli():
+def cli() -> None:
     pass
 
 
@@ -26,8 +26,8 @@ def cli():
               required=True,
               help="Do a dry run; print commands.",
               is_flag=True)
-def make_rasters_smaller_cmd(dir, dry_run):
-    def make_it_smaller(tif_path):
+def make_rasters_smaller_cmd(dir: str, dry_run: bool) -> None:
+    def make_it_smaller(tif_path: str) -> None:
         with TemporaryDirectory() as tmp_dir:
             tmp_path = os.path.join(tmp_dir, "smaller.tif")
             translate_cmd = [
@@ -48,7 +48,7 @@ def make_rasters_smaller_cmd(dir, dry_run):
                 make_it_smaller(full_path)
 
 
-def run_cli():
+def run_cli() -> None:
     cli(prog_name='testutils')
 
 

--- a/src/stactools/testing/cli_test.py
+++ b/src/stactools/testing/cli_test.py
@@ -4,11 +4,11 @@ from typing import List, Callable
 import unittest
 
 import click
-from click.testing import CliRunner
+from click.testing import CliRunner, Result
 
 
 class CliTestCase(unittest.TestCase, ABC):
-    def use_debug_logging(self):
+    def use_debug_logging(self) -> None:
         logger = logging.getLogger('stactools')
         logger.setLevel(logging.DEBUG)
 
@@ -19,16 +19,16 @@ class CliTestCase(unittest.TestCase, ABC):
 
         logger.addHandler(ch)
 
-    def setUp(self):
+    def setUp(self) -> None:
         @click.group()
-        def cli():
+        def cli() -> None:
             pass
 
         for create_subcommand in self.create_subcommand_functions():
             create_subcommand(cli)
         self.cli = cli
 
-    def run_command(self, cmd):
+    def run_command(self, cmd: str) -> Result:
         runner = CliRunner()
         result = runner.invoke(self.cli, cmd, catch_exceptions=False)
         if result.output:
@@ -36,6 +36,7 @@ class CliTestCase(unittest.TestCase, ABC):
         return result
 
     @abstractmethod
-    def create_subcommand_functions(self) -> List[Callable]:
+    def create_subcommand_functions(
+            self) -> List[Callable[[click.Group], click.Command]]:
         """Return list of 'create_command' functions from implementations"""
         pass

--- a/src/stactools/testing/test_data.py
+++ b/src/stactools/testing/test_data.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+from typing import Any, Dict
 from tempfile import TemporaryDirectory
 from zipfile import ZipFile
 
@@ -18,7 +19,7 @@ import fsspec
 
 
 class TestData:
-    def __init__(self, path, external_data={}):
+    def __init__(self, path: str, external_data: Dict[str, Any] = {}) -> None:
         """Creates a test data object for a given test script.
 
         Initialize this from, e.g., `tests/__init__.py`:


### PR DESCRIPTION
Closes #183 
`pystac 1.1.0` is required because it now publishes type information in its packages.

I had to add some error handling code to appease `mypy`, so I'd like to get this looked at carefully. I modified a lot of code I haven't dealt with before.


**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [ ] Documentation has been updated to reflect changes, if applicable.
- [ ] Changes are added to the [CHANGELOG](../CHANGELOG.md).
