### PR TITLE
Install stactools as part of the readthedocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,4 +16,6 @@ formats:
 python:
   version: 3.8
   install:
+    - method: pip
+      path: .
     - requirements: requirements-dev.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- ReadTheDocs ([#190](https://github.com/stac-utils/stactools/pull/190))
+
 ## stactools 0.2.1
 
 The v0.2 release of stactools is a major refactor of the packaging and organization strategy for stactools.


### PR DESCRIPTION
**Related Issue(s):** #143 

**Description:** As viewable [here](https://readthedocs.org/projects/stactools/builds/14371316/), our readthedocs build is failing because there's no `stactools` in the path. I'm guessing this is because we moved the code into a `src/` subdirectory as a part of the v0.2 update. By installing stactools into the virtualenvironment, hopefully this will go away.

This is hard to test b/c docs for pull requests isn't enabled (I think). @lossyrob I think you own our RTD account, would it be possible to turn on PR docs per https://docs.readthedocs.io/en/stable/pull-requests.html so we can see if we're fixing things?

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
