### PR TITLE
Add documentation for old GDAL versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ From source repository:
 > pip install .
 ```
 
+**NOTE:** In order to read and write Cloud Optimized Geotiffs, GDAL version 3.1 or greater is required.
+If your system GDAL is older than version 3.1, consider using [Docker](#using-docker) or [Conda](#using-conda) to get a modern GDAL.
+
 ### Optional dependencies
 
 `stactools` includes some optional dependencies:

--- a/src/stactools/core/utils/__init__.py
+++ b/src/stactools/core/utils/__init__.py
@@ -1,6 +1,7 @@
 from typing import Callable, Optional, TypeVar
 
 import fsspec
+import rasterio
 
 T = TypeVar('T')
 U = TypeVar('U')
@@ -21,3 +22,9 @@ def href_exists(href: str) -> bool:
     """
     fs, _, paths = fsspec.get_fs_token_paths(href)
     return bool(paths and fs.exists(paths[0]))
+
+
+def gdal_driver_is_enabled(name: str) -> bool:
+    """Checks to see if the named GDAL driver is enabled."""
+    with rasterio.Env() as env:
+        return name in env.drivers().keys()

--- a/src/stactools/core/utils/convert.py
+++ b/src/stactools/core/utils/convert.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 
 from stactools.core.utils.subprocess import call
+from stactools.core.utils import gdal_driver_is_enabled
 
 DEFAULT_COGIFY_ARGS = ["-co", "compress=deflate"]
 
@@ -10,6 +11,10 @@ def cogify(infile: str,
            args: Optional[List[str]] = None,
            extra_args: Optional[List[str]] = None) -> int:
     """Creates a COG from a GDAL-readable file."""
+    if not gdal_driver_is_enabled("COG"):
+        raise Exception(
+            "GDAL's COG driver is not enabled. "
+            "Please make sure your GDAL version is 3.1 or greater.")
     if args is None:
         args = DEFAULT_COGIFY_ARGS[:]
     args = ["gdal_translate", "-of", "COG"] + args


### PR DESCRIPTION
**Related Issue(s):** #193 

**Description:** GDAL older than 3.1 doesn't support COGs. This commit adds a more
sensible error message to the `cogify` function, and adds a README note
about how to get a newer GDAL.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [ ] Changes are added to the [CHANGELOG](../CHANGELOG.md).
