### PR TITLE
Enable fetching external data from the Microsoft Planetary Computer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Add the ability to use data from the Microsoft Planetary Computer as external testing data ([#197](https://github.com/stac-utils/stactools/pull/197))
+
 ### Changed
 
 - Improved error reporting and documentation for old GDAL versions.

--- a/scripts/lint
+++ b/scripts/lint
@@ -24,6 +24,6 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         # Lint
         flake8 ${DIRS_TO_CHECK[@]}
         # Type checking
-        mypy src
+        mypy --install-types --non-interactive src
     fi
 fi

--- a/tests/testing/__init__.py
+++ b/tests/testing/__init__.py
@@ -15,5 +15,15 @@ test_data = TestData(
                     "endpoint_url": "https://opentopography.s3.sdsc.edu"
                 }
             }
+        },
+        "manifest.safe": {
+            "url":
+            ("https://sentinel2l2a01.blob.core.windows.net/"
+             "sentinel2-l2/03/K/TV/"
+             "2020/05/23/"
+             "S2A_MSIL2A_20200523T213041_N0212_R100_T03KTV_20200910T164427.SAFE/"
+             "manifest.safe"),
+            "planetary_computer":
+            True
         }
     })

--- a/tests/testing/test_test_data.py
+++ b/tests/testing/test_test_data.py
@@ -21,6 +21,12 @@ class TestDataTest(TestCase):
             xml.find("ALPSMLC30_N041W106_DSM"), -1,
             "Could not find 'ALPSMLC30_N041W106_DSM' in the ALOS VRT")
 
+    def test_external_pc_data(self):
+        path = test_data.get_external_data("manifest.safe")
+        with open(path) as f:
+            xml = f.read()
+        self.assertIsNotNone(xml)
+
 
 def skip_without_s3fs():
     try:


### PR DESCRIPTION
Before you submit a pull request, please fill in the following:

**Description:**
Allow external data from the Microsoft Planetary Computer.

The PC hosts data that allows for anonymous download, but URLs must be signed first by requesting a token from `https://planetarycomputer.microsoft.com/api/sas/v1/sign?href={URL}`. This PR allows external test data to be marked with `"planetary_computer": True`, and modifies the logic to sign the URL of that external data if that flag is present.

In addition, mypy is unpinned in this repository so upgraded to a post-0.9 release, which caused some fixes to be required. Mypy no longer holds stubs for common libraries and so the linting script is changed to account for this. Also mypy errors on a type issue it hadn't before for a local variable in the projection logic, and an `Any` is put in place to avoid that issue.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`). 
- [ ] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
