### PR TITLE
Add stactools.core.create.item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- `stactools.core.create.item` and associated CLI subcommand ([#201](https://github.com/stac-utils/stactools/pull/201))
+
+### Fixed
+
+- Typing for Python 3.7 in `stactools.core.projection` ([#201](https://github.com/stac-utils/stactools/pull/201))
+
 ## stactools 0.2.2
 
 ### Added

--- a/src/stactools/cli/__init__.py
+++ b/src/stactools/cli/__init__.py
@@ -8,10 +8,11 @@ stactools.core.use_fsspec()
 def register_plugin(registry: 'Registry') -> None:
     # Register subcommands
 
-    from stactools.cli.commands import (add, copy, info, layout, merge,
-                                        migrate, validate, version)
+    from stactools.cli.commands import (add, copy, info, layout, merge, create,
+                                        version, validate)
 
     registry.register_subcommand(copy.create_copy_command)
+    registry.register_subcommand(create.create_create_item_command)
     registry.register_subcommand(copy.create_move_assets_command)
     registry.register_subcommand(info.create_info_command)
     registry.register_subcommand(info.create_describe_command)

--- a/src/stactools/cli/commands/create.py
+++ b/src/stactools/cli/commands/create.py
@@ -1,0 +1,20 @@
+import click
+
+from stactools.core import create
+
+
+def create_create_item_command(cli: click.Group) -> click.Command:
+    @cli.command('create-item', short_help='Creates an item from an asset')
+    @click.argument('href')
+    def create_item_command(href: str) -> None:
+        """Creates an Item from a href.
+
+        The href must be a `rasterio` readable asset. The item's dictionary will
+        be printed to stdout. This item is intentinonally _extremely_ minimal.
+        If you need additional capabilities, we recommend using [rio
+        stac](https://github.com/developmentseed/rio-stac/).
+        """
+        item = create.item(href)
+        print(item.to_dict())
+
+    return create_item_command

--- a/src/stactools/core/create.py
+++ b/src/stactools/core/create.py
@@ -1,0 +1,62 @@
+import datetime
+import os.path
+
+import shapely.geometry
+from pystac import Item, Asset
+from pystac.extensions.projection import ProjectionExtension
+import rasterio
+
+import stactools.core.projection
+
+
+def item(href: str) -> Item:
+    """Creates a STAC Item from the asset at the provided href.
+
+    This function is intentionally minimal in its signature and capabilities. If
+    you need to customize your Item, do so after creation.
+
+    This function sets:
+    - id
+    - geometry
+    - bbox
+    - datetime (to the time of item creation): you'll probably want to change this
+    - the proj extension
+        - either the EPSG code or, if not available, the WKT2
+        - transform
+        - shape
+    - a single asset with key 'data'
+        - asset href
+        - asset roles to ['data']
+
+    In particular, the datetime and asset media type fields most likely need to be updated.
+    """
+    id = os.path.splitext(os.path.basename(href))[0]
+    with rasterio.open(href) as dataset:
+        crs = dataset.crs
+        proj_bbox = dataset.bounds
+        proj_transform = list(dataset.transform)[0:6]
+        proj_shape = dataset.shape
+    proj_geometry = shapely.geometry.mapping(shapely.geometry.box(*proj_bbox))
+    geometry = stactools.core.projection.reproject_geom(crs,
+                                                        'EPSG:4326',
+                                                        proj_geometry,
+                                                        precision=6)
+    bbox = list(shapely.geometry.shape(geometry).bounds)
+    item = Item(id=id,
+                geometry=geometry,
+                bbox=bbox,
+                datetime=datetime.datetime.now(),
+                properties={})
+
+    projection = ProjectionExtension.ext(item, add_if_missing=True)
+    epsg = crs.to_epsg()
+    if epsg:
+        projection.epsg = epsg
+    else:
+        projection.wkt2 = crs.to_wkt('WKT2')
+    projection.transform = proj_transform
+    projection.shape = proj_shape
+
+    item.add_asset('data', Asset(href=href, roles=['data']))
+
+    return item

--- a/src/stactools/core/projection.py
+++ b/src/stactools/core/projection.py
@@ -1,6 +1,5 @@
-from collections import abc
 from copy import deepcopy
-from typing import Any, List, Optional, Union, Dict
+from typing import Any, List, Optional, Union, Dict, Sequence
 
 import pyproj
 import rasterio.crs
@@ -49,11 +48,11 @@ def reproject_geom(src_crs: Union[pyproj.CRS, rasterio.crs.CRS, str],
                                               always_xy=True)
     result = deepcopy(geom)
 
-    def fn(coords: abc.Sequence[Any]) -> abc.Sequence[Any]:
+    def fn(coords: Sequence[Any]) -> Sequence[Any]:
         coords = list(coords)
         for i in range(0, len(coords)):
             coord = coords[i]
-            if isinstance(coord[0], abc.Sequence):
+            if isinstance(coord[0], Sequence):
                 coords[i] = fn(coord)
             else:
                 x, y = coord

--- a/tests/core/test_create.py
+++ b/tests/core/test_create.py
@@ -1,0 +1,52 @@
+import os.path
+from unittest import TestCase
+
+from pystac.extensions.projection import ProjectionExtension
+
+from stactools.core import create
+
+from tests import test_data
+
+
+class CreateItem(TestCase):
+    def setUp(self) -> None:
+        self.path = test_data.get_path(
+            'data-files/planet-disaster/hurricane-harvey/'
+            'hurricane-harvey-0831/20170831_172754_101c/20170831_172754_101c_3b_Visual.tif'
+        )
+
+    def test_one_datetime(self) -> None:
+        item = create.item(self.path)
+        self.assertEqual(item.id,
+                         os.path.splitext(os.path.basename(self.path))[0])
+        self.assertIsNotNone(item.datetime)
+        self.assertEqual(
+            item.geometry, {
+                'type':
+                'Polygon',
+                'coordinates':
+                [[[-95.780872, 29.517294], [-95.783782, 29.623358],
+                  [-96.041791, 29.617689], [-96.038613, 29.511649],
+                  [-95.780872, 29.517294]]]
+            })
+        self.assertEqual(item.bbox,
+                         [-96.041791, 29.511649, -95.780872, 29.623358])
+        self.assertIsNone(item.common_metadata.start_datetime)
+        self.assertIsNone(item.common_metadata.end_datetime)
+
+        projection = ProjectionExtension.ext(item)
+        self.assertEqual(projection.epsg, 32615)
+        self.assertIsNone(projection.wkt2)
+        self.assertIsNone(projection.projjson)
+        self.assertEqual(
+            projection.transform,
+            [97.69921875, 0.0, 205437.0, 0.0, -45.9609375, 3280290.0])
+        self.assertEqual(projection.shape, (256, 256))
+
+        data = item.assets['data']
+        self.assertEqual(data.href, self.path)
+        self.assertIsNone(data.title)
+        self.assertIsNone(data.description)
+        self.assertEqual(data.roles, ['data'])
+        self.assertEqual(data.media_type, None)
+        item.validate()


### PR DESCRIPTION
**Related Issue(s):** #179 

**Description:** This creates an item from a `rasterio` openable asset. The function tries to fill in as much data as possible from the `rasterio` dataset, but generally created items should be enhanced after creation with additional properties and STAC extensions.

Also includes a drop-dead simple command line interface.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
