### PR TITLE
docs, ci: use conda env in readthedocs

### DIFF
--- a/.readthedocs.environment.yml
+++ b/.readthedocs.environment.yml
@@ -1,0 +1,29 @@
+name: stactools
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - gdal
+  - pip
+  - rasterio~=1.2
+  - pip:
+    - codespell
+    - coverage
+    - flake8
+    - ipython
+    - jupyter
+    - lxml-stubs
+    - mypy
+    - nbsphinx
+    - pylint
+    - sphinx
+    - sphinx-autobuild
+    - sphinx-click
+    - sphinxcontrib-fulltoc
+    - sphinxcontrib-napoleon
+    - types-certifi
+    - types-orjson
+    - types-python-dateutil
+    - types-requests
+    - yapf
+    - .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,9 +13,10 @@ sphinx:
 formats:
   - pdf
 
-python:
-  version: 3.8
-  install:
-    - method: pip
-      path: .
-    - requirements: requirements-dev.txt
+build:
+  os: ubuntu-20.04
+  tools:
+    python: mambaforge-4.10
+
+conda:
+  environment: .readthedocs.environment.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Fixed
 
+- Readthedocs build ([#210](https://github.com/stac-utils/stactools/pull/210))
+
 ## stactools 0.2.3
 
 ### Added


### PR DESCRIPTION
**Related Issue(s):** #207 

**Description:** Installs our entire environment via a readthedocs-specific environment file. Readthedoc can't do both conda and pip installs, so we have to do everything via conda to get `gdal` in the build.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
