### PR TITLE
feat: add read_href_modifier to create.item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- `read_href_modifer` argument to `stactools.create.item` ([#212](https://github.com/stac-utils/stactools/pull/212))
+
 ## stactools 0.2.4
 
 ### Added

--- a/src/stactools/cli/commands/add.py
+++ b/src/stactools/cli/commands/add.py
@@ -34,6 +34,7 @@ def add(source_item: str,
 
 
 def create_add_command(cli: click.Group) -> click.Command:
+
     @cli.command('add', short_help='Add an item to a catalog/collection.')
     @click.argument('source_item')
     @click.argument('target_catalog')

--- a/src/stactools/cli/commands/addraster.py
+++ b/src/stactools/cli/commands/addraster.py
@@ -12,6 +12,7 @@ def add_raster(item_path: str) -> None:
 
 
 def create_addraster_command(cli: click.Group) -> click.Command:
+
     @cli.command("addraster", short_help="Add raster extension to an Item.")
     @click.argument("item_path")
     def addraster_command(item_path: str) -> None:

--- a/src/stactools/cli/commands/copy.py
+++ b/src/stactools/cli/commands/copy.py
@@ -7,6 +7,7 @@ from stactools.core.copy import copy_catalog, move_all_assets
 
 
 def create_move_assets_command(cli: click.Group) -> click.Command:
+
     @cli.command(
         'move-assets',
         short_help='Move or copy assets in a STAC to the Item locations.')
@@ -48,6 +49,7 @@ def create_move_assets_command(cli: click.Group) -> click.Command:
 
 
 def create_copy_command(cli: click.Group) -> click.Command:
+
     @cli.command('copy', short_help='Copy a STAC Catalog')
     @click.argument('src')
     @click.argument('dst')

--- a/src/stactools/cli/commands/create.py
+++ b/src/stactools/cli/commands/create.py
@@ -4,6 +4,7 @@ from stactools.core import create
 
 
 def create_create_item_command(cli: click.Group) -> click.Command:
+
     @cli.command('create-item', short_help='Creates an item from an asset')
     @click.argument('href')
     def create_item_command(href: str) -> None:

--- a/src/stactools/cli/commands/info.py
+++ b/src/stactools/cli/commands/info.py
@@ -45,6 +45,7 @@ def print_info(catalog_path: str) -> None:
 
 
 def create_info_command(cli: click.Group) -> click.Command:
+
     @cli.command('info',
                  short_help='Display info about a static STAC catalog.')
     @click.argument('catalog_path')
@@ -55,6 +56,7 @@ def create_info_command(cli: click.Group) -> click.Command:
 
 
 def create_describe_command(cli: click.Group) -> click.Command:
+
     @cli.command(
         'describe',
         short_help='Prints out a list of all catalogs, collections and items '

--- a/src/stactools/cli/commands/layout.py
+++ b/src/stactools/cli/commands/layout.py
@@ -5,6 +5,7 @@ from stactools.core import layout_catalog
 
 
 def create_layout_command(cli: click.Group) -> click.Command:
+
     @cli.command(
         'layout',
         short_help='Reformat the layout of a STAC based on templating.')

--- a/src/stactools/cli/commands/merge.py
+++ b/src/stactools/cli/commands/merge.py
@@ -35,6 +35,7 @@ def merge(source_catalog: str,
 
 
 def create_merge_command(cli: click.Group) -> click.Command:
+
     @cli.command('merge', short_help='Merge items from one STAC into another.')
     @click.argument('source_catalog')
     @click.argument('target_catalog')

--- a/src/stactools/cli/commands/migrate.py
+++ b/src/stactools/cli/commands/migrate.py
@@ -7,6 +7,7 @@ def migrate(option: click.Option) -> None:
 
 
 def create_migrate_command(cli: click.Group) -> click.Command:
+
     @cli.command('migrate', short_help='Migrate a STAC catalog (TODO)')
     @click.option('--option', '-o', default=1, help='A test option')
     def migrate_command(option: click.Option) -> None:

--- a/src/stactools/cli/commands/validate.py
+++ b/src/stactools/cli/commands/validate.py
@@ -9,6 +9,7 @@ from stactools.core.utils import href_exists
 
 
 def create_validate_command(cli: click.Group) -> click.Command:
+
     @cli.command("validate", short_help="Validate a stac object.")
     @click.argument("href")
     @click.option("--recurse/--no-recurse",

--- a/src/stactools/cli/commands/version.py
+++ b/src/stactools/cli/commands/version.py
@@ -8,6 +8,7 @@ from click.core import Command, Group
 
 
 def create_version_command(cli: Group) -> Command:
+
     @cli.command('version', short_help='Display version info.')
     def version_command() -> None:
         """Display version info

--- a/src/stactools/cli/registry.py
+++ b/src/stactools/cli/registry.py
@@ -33,9 +33,7 @@ class Registry():
             # returned name an absolute name instead of a relative one. This allows
             # import_module to work without having to do additional modification to
             # the name.
-            return pkgutil.iter_modules(
-                ns_pkg.__path__,  # type: ignore  # mypy issue #1422
-                ns_pkg.__name__ + '.')
+            return pkgutil.iter_modules(ns_pkg.__path__, ns_pkg.__name__ + '.')
 
         discovered_plugins = {
             name: importlib.import_module(name)

--- a/src/stactools/cli/registry.py
+++ b/src/stactools/cli/registry.py
@@ -6,6 +6,7 @@ from click import Command, Group
 
 class Registry():
     """A registry for resources that are built-in or contributed by plugins."""
+
     def __init__(self) -> None:
         self._create_command_functions: List[Callable[[Group], Command]] = []
 

--- a/src/stactools/core/io/__init__.py
+++ b/src/stactools/core/io/__init__.py
@@ -20,6 +20,7 @@ def read_text(href: str,
 
 
 class FsspecStacIO(DefaultStacIO):
+
     def read_text_from_href(self, href: str, *args: Any, **kwargs: Any) -> str:
         with fsspec.open(href, "r") as f:
             s = f.read()

--- a/src/stactools/core/io/xml.py
+++ b/src/stactools/core/io/xml.py
@@ -11,6 +11,7 @@ class XmlElement:
     """Thin wrapper around lxml etree.Element with some
     convenience functions
     """
+
     def __init__(self, element: lxmlElement):
         self.element = element
 

--- a/src/stactools/core/utils/subprocess.py
+++ b/src/stactools/core/utils/subprocess.py
@@ -6,6 +6,7 @@ logger = logging.getLogger(__name__)
 
 
 def call(command: List[str]) -> int:
+
     def log_subprocess_output(pipe: IO[bytes]) -> None:
         for line in iter(pipe.readline, b''):  # b'\n'-separated lines
             logger.info(line.decode("utf-8").strip('\n'))

--- a/src/stactools/testing/cli.py
+++ b/src/stactools/testing/cli.py
@@ -27,6 +27,7 @@ def cli() -> None:
               help="Do a dry run; print commands.",
               is_flag=True)
 def make_rasters_smaller_cmd(dir: str, dry_run: bool) -> None:
+
     def make_it_smaller(tif_path: str) -> None:
         with TemporaryDirectory() as tmp_dir:
             tmp_path = os.path.join(tmp_dir, "smaller.tif")

--- a/src/stactools/testing/cli_test.py
+++ b/src/stactools/testing/cli_test.py
@@ -8,6 +8,7 @@ from click.testing import CliRunner, Result
 
 
 class CliTestCase(unittest.TestCase, ABC):
+
     def use_debug_logging(self) -> None:
         logger = logging.getLogger('stactools')
         logger.setLevel(logging.DEBUG)
@@ -20,6 +21,7 @@ class CliTestCase(unittest.TestCase, ABC):
         logger.addHandler(ch)
 
     def setUp(self) -> None:
+
         @click.group()
         def cli() -> None:
             pass

--- a/src/stactools/testing/test_data.py
+++ b/src/stactools/testing/test_data.py
@@ -20,6 +20,7 @@ import requests
 
 
 class TestData:
+
     def __init__(self, path: str, external_data: Dict[str, Any] = {}) -> None:
         """Creates a test data object for a given test script.
 

--- a/tests/cli/commands/test_add.py
+++ b/tests/cli/commands/test_add.py
@@ -18,6 +18,7 @@ def create_temp_catalog_copy(tmp_dir):
 
 
 class AddTest(CliTestCase):
+
     def create_subcommand_functions(self):
         return [create_add_command]
 

--- a/tests/cli/commands/test_addraster.py
+++ b/tests/cli/commands/test_addraster.py
@@ -20,6 +20,7 @@ def create_temp_catalog_copy(tmp_dir):
 
 
 class AddRasterTest(CliTestCase):
+
     def create_subcommand_functions(self):
         return [create_addraster_command]
 

--- a/tests/cli/commands/test_cases.py
+++ b/tests/cli/commands/test_cases.py
@@ -57,6 +57,7 @@ RANDOM_EXTENT = Extent(spatial=SpatialExtent.from_coordinates(
 
 
 class TestCases:
+
     @staticmethod
     def get_path(rel_path):
         return os.path.abspath(

--- a/tests/cli/commands/test_copy.py
+++ b/tests/cli/commands/test_copy.py
@@ -11,6 +11,7 @@ from .test_cases import TestCases
 
 
 class CopyTest(CliTestCase):
+
     def create_subcommand_functions(self):
         return [create_copy_command, create_move_assets_command]
 

--- a/tests/cli/commands/test_merge.py
+++ b/tests/cli/commands/test_merge.py
@@ -35,6 +35,7 @@ def copy_two_planet_disaster_subsets(tmp_dir):
 
 
 class MergeTest(CliTestCase):
+
     def create_subcommand_functions(self):
         return [create_merge_command]
 

--- a/tests/cli/commands/test_validate.py
+++ b/tests/cli/commands/test_validate.py
@@ -7,6 +7,7 @@ from tests import test_data
 
 
 class ValidatateTest(CliTestCase):
+
     def create_subcommand_functions(self) -> List[Callable]:
         return [create_validate_command]
 

--- a/tests/cli/commands/test_version.py
+++ b/tests/cli/commands/test_version.py
@@ -9,6 +9,7 @@ from stactools.testing import CliTestCase
 
 
 class VersionTest(CliTestCase):
+
     def create_subcommand_functions(self):
         return [create_version_command]
 

--- a/tests/core/test_create.py
+++ b/tests/core/test_create.py
@@ -50,3 +50,15 @@ class CreateItem(TestCase):
         self.assertEqual(data.roles, ['data'])
         self.assertEqual(data.media_type, None)
         item.validate()
+
+    def test_read_href_modifer(self) -> None:
+        did_it = False
+
+        def do_it(href: str) -> str:
+            nonlocal did_it
+            did_it = True
+            return href
+
+        item = create.item(self.path, read_href_modifier=do_it)
+        assert did_it
+        assert item.id == "20170831_172754_101c_3b_Visual"

--- a/tests/core/test_create.py
+++ b/tests/core/test_create.py
@@ -9,6 +9,7 @@ from tests import test_data
 
 
 class CreateItem(TestCase):
+
     def setUp(self) -> None:
         self.path = test_data.get_path(
             'data-files/planet-disaster/hurricane-harvey/'

--- a/tests/core/test_io.py
+++ b/tests/core/test_io.py
@@ -7,6 +7,7 @@ from stactools.core import use_fsspec
 
 
 class IOTest(unittest.TestCase):
+
     def test_fsspec_io(self):
         use_fsspec()
 

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -10,6 +10,7 @@ from tests import test_data
 
 
 class CogifyTest(unittest.TestCase):
+
     @contextmanager
     def cogify(self, **kwargs):
         infile = test_data.get_path("data-files/core/byte.tif")

--- a/tests/testing/test_test_data.py
+++ b/tests/testing/test_test_data.py
@@ -7,6 +7,7 @@ from tests.testing import test_data
 
 class TestDataTest(TestCase):
     """Say test ONE MORE TIME and I swear..."""
+
     def test_external_data_https(self):
         path = test_data.get_external_data("item.json")
         item = pystac.read_file(path)


### PR DESCRIPTION
**Related Issue(s):** n/a

**Description:** Add `read_href_modifer` argument to `create.item`. This allows signing urls when creating basic items.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
