### PR TITLE
Use pytest instead of unittest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+
+- Use [pytest](https://docs.pytest.org/) for unit testing instead of `unittest` ([#220](https://github.com/stac-utils/stactools/pull/220))
+
 ## [0.2.5] - 2022-01-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -181,10 +181,10 @@ or in the local environment with
 
 ### Unit Tests
 
-Unit tests are in the `tests` folder. To run unit tests, use `unittest`:
+Unit tests are in the `tests` folder. To run unit tests, use `pytest`:
 
 ```
-> python -m unittest discover tests
+> pytest tests
 ```
 
 To run linters, code formatters, and test suites all together, use `test`:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 codespell
-coverage
 flake8
 ipython
 jupyter
@@ -7,6 +6,8 @@ lxml-stubs
 mypy
 nbsphinx
 pylint
+pytest
+pytest-cov
 sphinx
 sphinx-autobuild
 sphinx-click

--- a/scripts/test
+++ b/scripts/test
@@ -27,7 +27,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
             docs/*.rst docs/**/*.rst \
             docs/*.ipynb docs/**/*.ipynb
 
-        coverage run --source=${COVERAGE_DIRS} -m unittest discover tests/
+        pytest --cov=stactools tests/
         coverage xml
     fi
 fi

--- a/src/stactools/testing/test_data.py
+++ b/src/stactools/testing/test_data.py
@@ -21,6 +21,8 @@ import requests
 
 class TestData:
 
+    __test__ = False
+
     def __init__(self, path: str, external_data: Dict[str, Any] = {}) -> None:
         """Creates a test data object for a given test script.
 


### PR DESCRIPTION
**Related Issue(s):** #218, #219

**Description:** Switch to **pytest** for unit testing. This is a pretty low-impact change, since **pytest** nicely picks up all of our existing `unittest.TestCase`s.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
