### PR TITLE
Don't push images from PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,5 @@
 version: 2
 updates:
-
   - package-ecosystem: "docker"
     directory: "/docker"
     schedule:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -70,18 +70,15 @@ jobs:
       packages: write
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v2
-      -
-        name: Login to GitHub Container Registry
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
           registry: ${{ env.DOCKER_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Docker meta main
+      - name: Docker meta main
         id: meta-main
         uses: docker/metadata-action@v3
         with:
@@ -89,8 +86,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-      -
-        name: Build and push main
+      - name: Build and push main
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -100,8 +96,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot') }}
           tags: ${{ steps.meta-main.outputs.tags }}
           labels: ${{ steps.meta-main.outputs.labels }}
-      -
-        name: Docker meta dev
+      - name: Docker meta dev
         id: meta-dev
         uses: docker/metadata-action@v3
         with:
@@ -111,8 +106,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-      -
-        name: Build and push dev
+      - name: Build and push dev
         uses: docker/build-push-action@v2
         with:
           context: .

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -92,8 +92,8 @@ jobs:
           context: .
           file: docker/Dockerfile
           target: main
-          # Don't try to push if the event is a PR from a fork or the user is dependabot
-          push: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot') }}
+          # Don't try to push if the event is a PR, from a fork, or the user is dependabot
+          push: ${{ github.event_name != 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot' }}
           tags: ${{ steps.meta-main.outputs.tags }}
           labels: ${{ steps.meta-main.outputs.labels }}
       - name: Docker meta dev
@@ -112,7 +112,7 @@ jobs:
           context: .
           file: docker/Dockerfile
           target: dev
-          # Don't try to push if the event is a PR from a fork
-          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+          # Don't try to push if the event is a PR or from a fork
+          push: ${{ github.event_name != 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
           tags: ${{ steps.meta-dev.outputs.tags }}
           labels: ${{ steps.meta-dev.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,18 +39,15 @@ jobs:
       packages: write
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v2
-      -
-        name: Login to GitHub Container Registry
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
           registry: ${{ env.DOCKER_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Docker meta main
+      - name: Docker meta main
         id: meta-main
         uses: docker/metadata-action@v3
         with:
@@ -59,8 +56,7 @@ jobs:
             latest=true
           tags: |
             type=pep440,pattern={{version}}
-      -
-        name: Build and push main
+      - name: Build and push main
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -69,8 +65,7 @@ jobs:
           push: true
           tags: ${{ steps.meta-main.outputs.tags }}
           labels: ${{ steps.meta-main.outputs.labels }}
-      -
-        name: Docker meta dev
+      - name: Docker meta dev
         id: meta-dev
         uses: docker/metadata-action@v3
         with:
@@ -80,8 +75,7 @@ jobs:
             suffix=-dev,onlatest=true
           tags: |
             type=pep440,pattern={{version}}
-      -
-        name: Build and push dev
+      - name: Build and push dev
         uses: docker/build-push-action@v2
         with:
           context: .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use [pytest](https://docs.pytest.org/) for unit testing instead of `unittest` ([#220](https://github.com/stac-utils/stactools/pull/220))
 - Signature of `stactools.core.utils.convert.cogify` ([#222](https://github.com/stac-utils/stactools/pull/222))
+- Don't push Docker images from pull requests ([#225](https://github.com/stac-utils/stactools/pull/225))
 
 ### Removed
 


### PR DESCRIPTION
**Related Issue(s):** #200, #203

**Description:** Don't push Docker images from pull requests.

Includes some linting on the Github actions yml files.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
