### PR TITLE
Switch to positive check for docker pushes

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -145,8 +145,8 @@ jobs:
           context: .
           file: docker/Dockerfile
           target: main
-          # Don't try to push if the event is a PR, from a fork, or the user is dependabot
-          push: ${{ github.event_name != 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot' }}
+          # Only push docker images if the event is a push to `main`
+          push: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
           tags: ${{ steps.meta-main.outputs.tags }}
           labels: ${{ steps.meta-main.outputs.labels }}
       - name: Docker meta dev
@@ -165,7 +165,7 @@ jobs:
           context: .
           file: docker/Dockerfile
           target: dev
-          # Don't try to push if the event is a PR or from a fork
-          push: ${{ github.event_name != 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+          # Only push docker images if the event is a push to `main`
+          push: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
           tags: ${{ steps.meta-dev.outputs.tags }}
           labels: ${{ steps.meta-dev.outputs.labels }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use [pytest](https://docs.pytest.org/) for unit testing instead of `unittest` ([#220](https://github.com/stac-utils/stactools/pull/220))
 - Signature of `stactools.core.utils.convert.cogify` ([#222](https://github.com/stac-utils/stactools/pull/222))
-- Don't push Docker images from pull requests ([#225](https://github.com/stac-utils/stactools/pull/225))
+- Don't push Docker images from pull requests ([#225](https://github.com/stac-utils/stactools/pull/225), [#226](https://github.com/stac-utils/stactools/pull/226))
 
 ### Removed
 


### PR DESCRIPTION
**Related Issue(s):**
- The previous attempt (#225) didn't work, so hopefully this one will.
- Closes #203

**Description:** I'm bad at Github actions, so my previous attempt to fix #203 didn't work -- I think because `github.event.pull_request.head.repo.full_name` was always null for the `push` to `main`. Hopefully this works. Sorry for the churn @duckontheweb.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
