### PR TITLE
Relax dependencies

### DIFF
--- a/.github/setup/action.yml
+++ b/.github/setup/action.yml
@@ -1,0 +1,36 @@
+name: Setup
+description: Set up the stactools testing environment with conda, pip, and associated caches
+inputs:
+  python-version:
+    description: Python version to set up w/ conda
+    required: True
+  pip-cache-hash:
+    description: The hash used for the pip cache
+    required: False
+    default: ${{ hashFiles('setup.cfg', 'requirements-dev.txt') }}
+runs:
+  using: composite
+  steps:
+    - name: Set up conda cache
+      uses: actions/cache@v2
+      with:
+        path: ~/conda_pkgs_dir
+        key: ${{ runner.os }}-conda-${{ hashFiles('environment.yml') }}
+        restore-keys: ${{ runner.os }}-conda-
+    - name: Set up pip cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ inputs.pip-cache-hash }}
+        restore-keys: ${{ runner.os }}-pip-
+    - name: Set up Conda with Python ${{ inputs.python-version }}
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        auto-update-conda: true
+        python-version: ${{ inputs.python-version }}
+    - name: Update Conda's environemnt
+      run: conda env update -f environment.yml -n test
+      shell: bash -l {0}
+    - name: Update pip
+      run: python -m pip install --upgrade pip
+      shell: bash -l {0}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,21 +11,8 @@ env:
   DOCKER_IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  codecov:
-    name: codecov
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Execute linters and test suites
-        run: ./docker/cibuild
-      - name: Upload All coverage to Codecov
-        uses: codecov/codecov-action@v2.1.0
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
-          fail_ci_if_error: false
-  python-matrix:
-    name: python-matrix
+  standard:
+    name: Standard
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -35,36 +22,100 @@ jobs:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@v2
-      - name: Set up conda cache
-        uses: actions/cache@v2
+      - uses: ./.github/setup
         with:
-          path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-conda-${{ hashFiles('**/environment.yml') }}
-          restore-keys: ${{ runner.os }}-conda-
-      - name: Set up pip cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.cfg', '**/requirements-dev.txt') }}
-          restore-keys: ${{ runner.os }}-pip-
-      - name: Set up Conda with Python ${{ matrix.python-version }}
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
           python-version: ${{ matrix.python-version }}
-      - name: Update Conda's environemnt
-        run: conda env update -f environment.yml -n test
-      - name: Execute linters and test suites
-        run: ./scripts/cibuild
-      - name: Install with extra_requires
-        run: pip install -e '.[all]'
-      - name: Test again
+      - name: Update
+        run: ./scripts/update
+      - name: Test
         run: ./scripts/test
-  docker:
-    name: docker
+  extra-requires:
+    name: Extra requires
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/setup
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install with extra_requires
+        run: pip install '.[all]'
+      - name: Install development dependencies
+        run: pip install -r requirements-dev.txt
+      - name: Test
+        run: ./scripts/test
+  minimum-versions:
+    name: Minimum versions
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/setup
+        with:
+          python-version: ${{ matrix.python-version }}
+          pip-cache-hash: ${{ hashFiles('requirements-min.txt', 'requirements-dev.txt') }}
+      - name: Install minimum requirements
+        run: pip install -r requirements-min.txt
+      - name: Install the package
+        run: pip install .
+      - name: Install development dependencies
+        run: pip install -r requirements-dev.txt
+      - name: Test
+        run: scripts/test
+  pre-release-versions:
+    name: Pre-release versions
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/setup
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Update
+        run: scripts/update
+      - name: Install pre-release versions of rasterio and pystac
+        run: pip install -U --pre pystac rasterio
+      - name: Run tests
+        run: unset PROJ_LIB && scripts/test
+  codecov:
+    name: Codecov
     needs:
-      - codecov
-      - python-matrix
+      - standard
+      - extra-requires
+      - minimum-versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Execute linters and test suites
+        run: ./docker/cibuild
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2.1.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
+          fail_ci_if_error: false
+  docker:
+    name: Docker
+    needs:
+      - standard
+      - extra-requires
+      - minimum-versions
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -70,6 +70,8 @@ jobs:
         run: pip install .
       - name: Install development dependencies
         run: pip install -r requirements-dev.txt
+      - name: Check minimum requirements
+        run: scripts/check_minimum_requirements
       - name: Test
         run: scripts/test
   pre-release-versions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- CI checks for minimum and pre-release versions of dependencies ([#228](https://github.com/stac-utils/stactools/pull/228))
+
 ### Changed
 
 - Use [pytest](https://docs.pytest.org/) for unit testing instead of `unittest` ([#220](https://github.com/stac-utils/stactools/pull/220))
@@ -16,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - GDAL Python bindings dependency ([#222](https://github.com/stac-utils/stactools/pull/222))
+- Upper bounds on dependencies ([#228](https://github.com/stac-utils/stactools/pull/228))
 
 ## [0.2.5] - 2022-01-03
 

--- a/environment.yml
+++ b/environment.yml
@@ -3,5 +3,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - gdal
-  - rasterio~=1.2
+  - gdal>=3.3
+  - geos>=3.3
+  - rasterio>=1.2

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,6 +4,7 @@ explicit_package_bases = True
 namespace_packages = True
 show_error_codes = True
 strict = True
+warn_unused_ignores = False
 
 [mypy-fsspec.*]
 ignore_missing_imports = True

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,12 @@
 codespell
 flake8
+importlib-metadata
 ipython
 jupyter
 lxml-stubs
 mypy
 nbsphinx
+packaging
 pylint
 pytest
 pytest-cov

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,0 +1,10 @@
+Shapely == 1.6
+aiohttp == 3.8
+click == 8.0.3
+fsspec == 2021.7
+lxml == 4.6
+numpy == 1.21.0
+pyproj == 3.0
+pystac[validation] == 1.2
+rasterio == 1.2.7
+requests == 2.20

--- a/scripts/check_minimum_requirements
+++ b/scripts/check_minimum_requirements
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# type: ignore
+
+import os.path
+import sys
+from importlib_metadata import requires
+from packaging.requirements import Requirement
+
+package_requirements = [
+    Requirement(requirement) for requirement in requires("stactools")
+]
+requirements_min = os.path.join(os.path.dirname(os.path.dirname(__file__)),
+                                "requirements-min.txt")
+with open(requirements_min) as file:
+    min_requirements = [Requirement(line) for line in file]
+min_requirements = dict(
+    (requirement.name, requirement) for requirement in min_requirements)
+
+incorrect_requirements = list()
+for package_requirement in package_requirements:
+    if package_requirement.marker is not None:
+        continue
+    min_requirement = min_requirements[package_requirement.name]
+    for (package_specifier,
+         min_specifier) in zip(package_requirement.specifier,
+                               min_requirement.specifier):
+        if package_specifier.operator == ">=" and package_specifier.version != min_specifier.version:
+            incorrect_requirements.append(
+                (package_requirement, min_requirement))
+
+if incorrect_requirements:
+    print("ERROR: Incorrect min-requirements.txt!")
+    for package_requirement, min_requirement in incorrect_requirements:
+        print(f"- package: {package_requirement}, min: {min_requirement}")
+    sys.exit(1)
+else:
+    print("OK")
+    sys.exit(0)

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,21 +31,22 @@ packages = find_namespace:
 zip_safe = False
 include_package_data = True
 install_requires =
-    Shapely ~= 1.7
-    aiohttp ~= 3.7
-    click ~= 8.0
-    fsspec ~= 2021.7
-    lxml ~= 4.6
-    pyproj ~= 3.0
-    pystac[validation] ~= 1.2
-    rasterio ~= 1.2
-    requests ~= 2.25
+    Shapely >= 1.6
+    aiohttp >= 3.8
+    click >= 8.0.3
+    fsspec >= 2021.7
+    lxml >= 4.6
+    numpy >= 1.21.0
+    pyproj >= 3.0
+    pystac[validation] >= 1.2
+    rasterio >= 1.2.7
+    requests >= 2.20
 
 [options.extras_require]
 all =
     %(s3)s
 s3 =
-    s3fs ~= 2021.7
+    s3fs >= 2021.7
 
 [options.packages.find]
 where = src

--- a/src/stactools/core/addraster.py
+++ b/src/stactools/core/addraster.py
@@ -43,6 +43,11 @@ def _read_bands(href: str) -> List[RasterBand]:
             band.nodata = dataset.nodatavals[i]
             band.spatial_resolution = dataset.transform[0]
             band.data_type = DataType(dataset.dtypes[i])
+            # These `type: ignore` comments are required until `numpy>=1.22.0`.
+            # When the minimum numpy version reaches v1.22.0 (which requires us
+            # to drop Python 3.7), then we can remove these `type: ignore`
+            # comments and remove the `warn_unused_ignores = True` line from
+            # `mypy.ini`.
             minimum = float(numpy.min(data))  # type: ignore
             maximum = float(numpy.max(data))  # type: ignore
             band.statistics = Statistics.create(minimum=minimum,


### PR DESCRIPTION
**Related Issue(s):**
- Closes #227 
- Relates to #223 in that we can't use `numpy>=1.22.0` until we drop Python 3.7, and until we do we need some `# type: ignore` comments on a couple of numpy calls that need to be ignored for newer numpy versions.

**Description:**
- Removes the upper bounds on our dependencies.
- Lowers the lower bounds on our dependencies, where possible. This process was pretty unscientific, mostly just manually installing versions and running the test suite.
- Adds `minimum-versions` and `pre-release-versions` to our CI.
- Changes the names of the python build actions
- Breaks `python-matrix` into `standard` and `extra-requires`
- Refactors the Python setup to repository-specific composite action to reduce duplication in the workflow file

Note that we had to unset `PROJ_LIB` to get the pre-release to pass, as described here: https://github.com/rasterio/rasterio/blob/master/docs/faq.rst#why-cant-rasterio-find-projdb-rasterio-from-pypi-versions--120. Not quite sure the correct approach to future-proof ourselves here, so going to just leave this as the solution in lieu of a better suggestion.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
- [x] Bring "required" actions into sync with the new actions/names (will be done after approval)
