### PR TITLE
Release v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.6] - 2022-02-15
 
 ### Added
 
@@ -216,7 +216,8 @@ See [#9](https://github.com/stac-utils/stactools/pull/9)
 - `stac.cli.command.layout` for modfiygin the layout of STACs
 - `stac.browse` for launching a local instance of stac-browser using docker.
 
-[Unreleased]: <https://github.com/stac-utils/stactools/compare/v0.2.5..main>
+[Unreleased]: <https://github.com/stac-utils/stactools/compare/v0.2.6..main>
+[0.2.6]: <https://github.com/stac-utils/stactools/compare/v0.2.5..v0.2.6>
 [0.2.5]: <https://github.com/stac-utils/stactools/compare/v0.2.4..v0.2.5>
 [0.2.4]: <https://github.com/stac-utils/stactools/compare/v0.2.3..v0.2.4>
 [0.2.3]: <https://github.com/stac-utils/stactools/compare/v0.2.2..v0.2.3>

--- a/src/stactools/core/__init__.py
+++ b/src/stactools/core/__init__.py
@@ -20,4 +20,4 @@ __all__ = [
     "move_all_assets",
     "use_fsspec",
 ]
-__version__ = "0.2.5"
+__version__ = "0.2.6"


### PR DESCRIPTION
**Related Issue(s):** None

**Description:** This is to get the GDAL python bindings removal (#216) onto pypi, so we stop breaking downstreams. E.g. https://github.com/stactools-packages/modis/runs/5204211709?check_suite_focus=true#step:7:135.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).

## Release summary

### Added

- CI checks for minimum and pre-release versions of dependencies ([#228](https://github.com/stac-utils/stactools/pull/228))

### Changed

- Use [pytest](https://docs.pytest.org/) for unit testing instead of `unittest` ([#220](https://github.com/stac-utils/stactools/pull/220))
- Signature of `stactools.core.utils.convert.cogify` ([#222](https://github.com/stac-utils/stactools/pull/222))
- Don't push Docker images from pull requests ([#225](https://github.com/stac-utils/stactools/pull/225), [#226](https://github.com/stac-utils/stactools/pull/226))

### Removed

- GDAL Python bindings dependency ([#222](https://github.com/stac-utils/stactools/pull/222))
- Upper bounds on dependencies ([#228](https://github.com/stac-utils/stactools/pull/228))
