### PR TITLE
Docs Makefile update for latest sphinx-autobuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documentation on the release process ([#241](https://github.com/stac-utils/stactools/pull/241))
 - `stac lint` using [stac-check](https://github.com/philvarner/stac-check) ([#254](https://github.com/stac-utils/stactools/pull/254))
 - `stac info` now has option `-s` or `--skip_items` to skip counting and printing catalog item info ([#14](https://github.com/stac-utils/stactools/issues/14))
+- updated `livehtml` target for documentation build to work with latest `sphinx-autobuild`
 
 ## [0.2.6] - 2022-02-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Documentation on the release process ([#241](https://github.com/stac-utils/stactools/pull/241))
 - `stac lint` using [stac-check](https://github.com/philvarner/stac-check) ([#254](https://github.com/stac-utils/stactools/pull/254))
-- `stac info` now has option `-s` or `--skip_items` to skip counting and printing catalog item info ([#14](https://github.com/stac-utils/stactools/issues/14))
-- updated `livehtml` target for documentation build to work with latest `sphinx-autobuild`
+- `stac info` now has option `-s` or `--skip_items` to skip counting and printing catalog item info ([#260](https://github.com/stac-utils/stactools/pull/260))
+- updated `livehtml` target for documentation build to work with latest `sphinx-autobuild` ([#261](https://github.com/stac-utils/stactools/pull/261))
 
 ## [0.2.6] - 2022-02-15
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,7 +12,7 @@ help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 livehtml:
-	sphinx-autobuild -z ../stactools --host 0.0.0.0 ${SOURCEDIR} $(BUILDDIR)/html -d _build/doctrees
+	sphinx-autobuild --watch ../stactools --host 0.0.0.0 ${SOURCEDIR} $(BUILDDIR)/html -d _build/doctrees
 
 .PHONY: help Makefile
 


### PR DESCRIPTION
**Related Issue(s):**
NA

**Description:**
Update the `Makefile` for the docs `livehtml` target. The latest version of `sphinx-autobuild` removes `-z`, but keeps `--watch`.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
