### PR TITLE
Progressive console output for `stac info`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - CI check for Python 3.10 (requires pre-release version of rasterio 1.3) ([#271](https://github.com/stac-utils/stactools/pull/271))
 - pre-commit and isort ([#275](https://github.com/stac-utils/stactools/pull/275))
+- `stac info` now has option `-p` or `--progress` to update console output while reading the catalog ([#262](https://github.com/stac-utils/stactools/pull/262))
 - More API documentation ([#282](https://github.com/stac-utils/stactools/pull/282))
 
 ### Changed

--- a/src/stactools/cli/commands/info.py
+++ b/src/stactools/cli/commands/info.py
@@ -22,7 +22,7 @@ def print_info(
         nonlocal max_line_length
         line = (
             f"\rCatalogs={cat_count}, Collections={col_count}, "
-            "Items={item_count}: Reading {root}"
+            f"Items={item_count}: Reading {root}"
         )
         if len(line) > max_line_length:
             max_line_length = len(line)

--- a/src/stactools/cli/commands/info.py
+++ b/src/stactools/cli/commands/info.py
@@ -1,15 +1,33 @@
 import click
 import pystac
+from pystac import Catalog, STACObject
 
 
-def print_info(catalog_path: str, skip_items: bool = False) -> None:
+def print_info(
+    catalog_path: str, skip_items: bool = False, print_progress: bool = False
+) -> None:
     cat_count, col_count, item_count = 0, 0, 0
     cat_ext, col_ext, item_ext = set([]), set([]), set([])
 
     cat = pystac.read_file(catalog_path)
-    if not isinstance(cat, pystac.Catalog):
+    if not isinstance(cat, Catalog):
         print("{} is not a catalog".format(catalog_path))
         return
+
+    cat_id_info = "Catalog ID: {}".format(cat.id)
+
+    max_line_length = 0
+
+    def progress_print(root: STACObject) -> None:
+        nonlocal max_line_length
+        line = (
+            f"\rCatalogs={cat_count}, Collections={col_count}, "
+            "Items={item_count}: Reading {root}"
+        )
+        if len(line) > max_line_length:
+            max_line_length = len(line)
+        print("\r" + " " * max_line_length, end="")
+        print(line, end="")
 
     for root, _, items in cat.walk():
         if root.STAC_OBJECT_TYPE == pystac.STACObjectType.COLLECTION:
@@ -28,26 +46,37 @@ def print_info(catalog_path: str, skip_items: bool = False) -> None:
                 if item.stac_extensions is not None:
                     for ext in item.stac_extensions:
                         item_ext.add(ext)
+        if print_progress:
+            progress_print(root)
 
-    cat_id_info = "Catalog ID: {}".format(cat.id)
     cat_ext_info = "(extensions: {})".format(",".join(cat_ext)) if cat_ext else ""
     col_ext_info = "(extensions: {})".format(",".join(col_ext)) if col_ext else ""
     item_ext_info = "(extensions: {})".format(",".join(item_ext)) if item_ext else ""
 
-    print(cat_id_info)
-    print("-" * len(cat_id_info))
-    print("   CATALOGS: {} {}".format(cat_count, cat_ext_info))
-    print("COLLECTIONS: {} {}".format(col_count, col_ext_info))
+    cat_text = "   CATALOGS: {} {}".format(cat_count, cat_ext_info)
+    col_text = "COLLECTIONS: {} {}".format(col_count, col_ext_info)
+    item_text = "      ITEMS: {} {}".format(item_count, item_ext_info)
+
+    lines = [cat_id_info, "-" * len(cat_id_info), cat_text, col_text]
     if not skip_items:
-        print("      ITEMS: {} {}".format(item_count, item_ext_info))
+        lines.append(item_text)
+
+    print("\r" + " " * max_line_length, end="")
+    output = "\n".join(lines)
+    print(f"\r{output}")
 
 
 def create_info_command(cli: click.Group) -> click.Command:
     @cli.command("info", short_help="Display info about a static STAC catalog.")
     @click.argument("catalog_path")
     @click.option("-s", "--skip_items", is_flag=True, help="Skip counting items")
-    def info_command(catalog_path: str, skip_items: bool) -> None:
-        print_info(catalog_path, skip_items)
+    @click.option(
+        "--progress/--no-progress",
+        default=True,
+        help="Display and update the output info while reading the catalog.",
+    )
+    def info_command(catalog_path: str, skip_items: bool, progress: bool) -> None:
+        print_info(catalog_path, skip_items, progress)
 
     return info_command
 

--- a/tests/cli/commands/test_cases.py
+++ b/tests/cli/commands/test_cases.py
@@ -75,6 +75,8 @@ RANDOM_EXTENT = Extent(
 
 
 class TestCases:
+    __test__ = False
+
     @staticmethod
     def get_path(rel_path):
         return os.path.abspath(os.path.join(os.path.dirname(__file__), "..", rel_path))

--- a/tests/cli/commands/test_cases.py
+++ b/tests/cli/commands/test_cases.py
@@ -5,6 +5,7 @@ import pystac
 from pystac import (
     Asset,
     Catalog,
+    Collection,
     Extent,
     Item,
     MediaType,
@@ -95,7 +96,7 @@ class TestCases:
         ]
 
     @staticmethod
-    def planet_disaster():
+    def planet_disaster() -> Collection:
         return pystac.read_file(
             test_data.get_path("data-files/planet-disaster/collection.json")
         )

--- a/tests/cli/commands/test_info.py
+++ b/tests/cli/commands/test_info.py
@@ -1,0 +1,23 @@
+from typing import Callable, List
+
+from click import Command, Group
+
+from stactools.cli.commands.info import create_describe_command, create_info_command
+from stactools.testing.cli_test import CliTestCase
+
+from .test_cases import TestCases
+
+
+class InfoTest(CliTestCase):
+    def create_subcommand_functions(self) -> List[Callable[[Group], Command]]:
+        return [create_info_command, create_describe_command]
+
+    def test_info(self) -> None:
+        cat = TestCases.planet_disaster()
+        result = self.run_command(f"info {cat.get_self_href()}")
+        assert result.exit_code == 0
+
+    def test_describe(self) -> None:
+        cat = TestCases.planet_disaster()
+        result = self.run_command(f"describe {cat.get_self_href()}")
+        assert result.exit_code == 0


### PR DESCRIPTION
**Related Issue(s):**
#13 

**Description:**
Added `-p` & `--progress` options for `stac info`. The output is overwritten on every step through the catalog. Extensions are only printed at the end. 

I didn't see any difference in runtime when testing against the largest catalogs in this repo's `tests/data-files` dir. 

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
