### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.0] - 2022-03-25
 
 ### Added
 
@@ -230,7 +230,8 @@ See [#9](https://github.com/stac-utils/stactools/pull/9)
 - `stac.cli.command.layout` for modfiygin the layout of STACs
 - `stac.browse` for launching a local instance of stac-browser using docker.
 
-[Unreleased]: <https://github.com/stac-utils/stactools/compare/v0.2.6..main>
+[Unreleased]: <https://github.com/stac-utils/stactools/compare/v0.3.0..main>
+[0.3.0]: <https://github.com/stac-utils/stactools/compare/v0.2.6..v0.3.0>
 [0.2.6]: <https://github.com/stac-utils/stactools/compare/v0.2.5..v0.2.6>
 [0.2.5]: <https://github.com/stac-utils/stactools/compare/v0.2.4..v0.2.5>
 [0.2.4]: <https://github.com/stac-utils/stactools/compare/v0.2.3..v0.2.4>

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,6 +15,8 @@ sphinx-autobuild
 sphinx-click
 sphinxcontrib-fulltoc
 sphinxcontrib-napoleon
+# an explicit toml installation is required until https://github.com/google/yapf/commit/fb0fbb47723612608a7c64cb3835562160ea834c is released
+toml
 types-certifi
 types-orjson
 types-python-dateutil

--- a/src/stactools/core/__init__.py
+++ b/src/stactools/core/__init__.py
@@ -20,4 +20,4 @@ __all__ = [
     "move_all_assets",
     "use_fsspec",
 ]
-__version__ = "0.2.6"
+__version__ = "0.3.0"


### PR DESCRIPTION
**Related Issue(s):**
- https://github.com/stac-utils/stactools/milestone/7

**Description:**
Update to v0.3.0. While this release doesn't have breaking changes in it, v0.2.6 did (https://github.com/stac-utils/stactools/pull/222) so a "major" release is appropriate (where "major" means v0.2 -> v0.3 since the first number is `0`).

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
