### PR TITLE
deps: skip click 8.1.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,8 @@ include_package_data = True
 install_requires =
     Shapely >= 1.6
     aiohttp >= 3.8
-    click >= 8.0.4
+    # Click 8.1.0 is excluded because it broke decorator typing: https://github.com/pallets/click/issues/2227
+    click >= 8.0.4, != 8.1.0
     fsspec >= 2021.7
     lxml >= 4.6
     numpy >= 1.21.0


### PR DESCRIPTION
**Related Issue(s):**
- Closes #265

**Description:** Click 8.1.0 broke decorator typing: https://github.com/pallets/click/issues/2227.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [ ] Changes are added to the [CHANGELOG](../CHANGELOG.md).
