### PR TITLE
Format with black

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,7 +9,4 @@ max-line-length = 100
 # W503, W504: flake8 reports this as incorrect, and scripts/format_code
 # changes code to it, so let format_code win.
 
-# E126: Continuation line over-indented for hanging indent
-# Conflicts with yapf formatting
-
-ignore = E127,W503,W504,E126
+ignore = E127,W503,W504

--- a/.readthedocs.environment.yml
+++ b/.readthedocs.environment.yml
@@ -7,23 +7,23 @@ dependencies:
   - pip
   - rasterio~=1.2
   - pip:
-    - codespell
-    - coverage
-    - flake8
-    - ipython
-    - jupyter
-    - lxml-stubs
-    - mypy
-    - nbsphinx
-    - pylint
-    - sphinx
-    - sphinx-autobuild
-    - sphinx-click
-    - sphinxcontrib-fulltoc
-    - sphinxcontrib-napoleon
-    - types-certifi
-    - types-orjson
-    - types-python-dateutil
-    - types-requests
-    - yapf
-    - .
+      - black
+      - codespell
+      - coverage
+      - flake8
+      - ipython
+      - jupyter
+      - lxml-stubs
+      - mypy
+      - nbsphinx
+      - pylint
+      - sphinx
+      - sphinx-autobuild
+      - sphinx-click
+      - sphinxcontrib-fulltoc
+      - sphinxcontrib-napoleon
+      - types-certifi
+      - types-orjson
+      - types-python-dateutil
+      - types-requests
+      - .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Skip Click v8.1.0 as it broke decorator typing ([#266](https://github.com/stac-utils/stactools/pull/266))
+- Use black (instead of yapf) for formatting ([#274](https://github.com/stac-utils/stactools/pull/274))
 
 ## [0.3.0] - 2022-03-25
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+black
 codespell
 flake8
 importlib-metadata
@@ -15,10 +16,7 @@ sphinx-autobuild
 sphinx-click
 sphinxcontrib-fulltoc
 sphinxcontrib-napoleon
-# an explicit toml installation is required until https://github.com/google/yapf/commit/fb0fbb47723612608a7c64cb3835562160ea834c is released
-toml
 types-certifi
 types-orjson
 types-python-dateutil
 types-requests
-yapf

--- a/scripts/format
+++ b/scripts/format
@@ -9,7 +9,7 @@ fi
 function usage() {
     echo -n \
         "Usage: $(basename "$0")
-Format code with yapf
+Format code with black
 "
 }
 
@@ -20,6 +20,6 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         usage
     else
         # Code formatting
-        yapf -ipr ${DIRS_TO_CHECK[@]}
+        black ${DIRS_TO_CHECK[@]}
     fi
 fi

--- a/scripts/lint
+++ b/scripts/lint
@@ -20,7 +20,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         usage
     else
         # Code formatting
-        yapf -dpr ${DIRS_TO_CHECK[@]}
+        scripts/format
         # Lint
         flake8 ${DIRS_TO_CHECK[@]}
         # Type checking

--- a/src/stactools/cli/__init__.py
+++ b/src/stactools/cli/__init__.py
@@ -5,12 +5,22 @@ import stactools.core
 stactools.core.use_fsspec()
 
 
-def register_plugin(registry: 'Registry') -> None:
+def register_plugin(registry: "Registry") -> None:
     # Register subcommands
 
-    from stactools.cli.commands import (add, addraster, copy, create, info,
-                                        layout, lint, merge, migrate, version,
-                                        validate)
+    from stactools.cli.commands import (
+        add,
+        addraster,
+        copy,
+        create,
+        info,
+        layout,
+        lint,
+        merge,
+        migrate,
+        version,
+        validate,
+    )
 
     registry.register_subcommand(add.create_add_command)
     registry.register_subcommand(addraster.create_addraster_command)

--- a/src/stactools/cli/cli.py
+++ b/src/stactools/cli/cli.py
@@ -6,23 +6,20 @@ from stactools.cli import registry
 
 
 def setup_logging(level: Union[str, int]) -> None:
-    logger = logging.getLogger('stactools')
+    logger = logging.getLogger("stactools")
     logger.setLevel(level)
 
     ch = logging.StreamHandler()
     ch.setLevel(level)
-    formatter = logging.Formatter('%(message)s')
+    formatter = logging.Formatter("%(message)s")
     ch.setFormatter(formatter)
 
     logger.addHandler(ch)
 
 
 @click.group()
-@click.option('-v', '--verbose', help=("Use verbose mode"), is_flag=True)
-@click.option('-q',
-              '--quiet',
-              help=("Use quiet mode (no output)"),
-              is_flag=True)
+@click.option("-v", "--verbose", help=("Use verbose mode"), is_flag=True)
+@click.option("-q", "--quiet", help=("Use quiet mode (no output)"), is_flag=True)
 def cli(verbose: bool, quiet: bool) -> None:
     logging_level = logging.INFO
     if verbose:
@@ -37,7 +34,7 @@ for create_subcommand in registry.get_create_subcommand_functions():
 
 
 def run_cli() -> None:
-    cli(prog_name='stac')
+    cli(prog_name="stac")
 
 
 if __name__ == "__main__":

--- a/src/stactools/cli/commands/add.py
+++ b/src/stactools/cli/commands/add.py
@@ -7,10 +7,12 @@ from pystac import Catalog, Item, read_file
 from stactools.core import add_item
 
 
-def add(source_item: str,
-        target_catalog: str,
-        collection_id: Optional[str] = None,
-        move_assets: bool = False) -> None:
+def add(
+    source_item: str,
+    target_catalog: str,
+    collection_id: Optional[str] = None,
+    move_assets: bool = False,
+) -> None:
     source = read_file(source_item)
     if not isinstance(source, Item):
         raise click.BadArgumentUsage(f"{source_item} is not a STAC Item")
@@ -22,9 +24,11 @@ def add(source_item: str,
         target_collection = target.get_child(collection_id, recursive=True)
         if target_collection is None:
             raise click.BadOptionUsage(
-                'collection',
-                'A collection with ID {} does not exist in {}'.format(
-                    collection_id, target_catalog))
+                "collection",
+                "A collection with ID {} does not exist in {}".format(
+                    collection_id, target_catalog
+                ),
+            )
 
         add_item(source, target_collection, move_assets)
         target_collection.save()
@@ -34,22 +38,30 @@ def add(source_item: str,
 
 
 def create_add_command(cli: click.Group) -> click.Command:
-
-    @cli.command('add', short_help='Add an item to a catalog/collection.')
-    @click.argument('source_item')
-    @click.argument('target_catalog')
-    @click.option('--collection',
-                  help=("The collection ID to add to. If not set, will "
-                        "add to the root catalog or collection."))
-    @click.option('-a',
-                  '--move-assets',
-                  is_flag=True,
-                  help='Move assets to the target catalog Item locations.')
-    def add_command(source_item: str, target_catalog: str, collection: str,
-                    move_assets: bool) -> None:
-        add(source_item,
+    @cli.command("add", short_help="Add an item to a catalog/collection.")
+    @click.argument("source_item")
+    @click.argument("target_catalog")
+    @click.option(
+        "--collection",
+        help=(
+            "The collection ID to add to. If not set, will "
+            "add to the root catalog or collection."
+        ),
+    )
+    @click.option(
+        "-a",
+        "--move-assets",
+        is_flag=True,
+        help="Move assets to the target catalog Item locations.",
+    )
+    def add_command(
+        source_item: str, target_catalog: str, collection: str, move_assets: bool
+    ) -> None:
+        add(
+            source_item,
             target_catalog,
             collection_id=collection,
-            move_assets=move_assets)
+            move_assets=move_assets,
+        )
 
     return add_command

--- a/src/stactools/cli/commands/addraster.py
+++ b/src/stactools/cli/commands/addraster.py
@@ -12,7 +12,6 @@ def add_raster(item_path: str) -> None:
 
 
 def create_addraster_command(cli: click.Group) -> click.Command:
-
     @cli.command("addraster", short_help="Add raster extension to an Item.")
     @click.argument("item_path")
     def addraster_command(item_path: str) -> None:

--- a/src/stactools/cli/commands/copy.py
+++ b/src/stactools/cli/commands/copy.py
@@ -7,22 +7,23 @@ from stactools.core.copy import copy_catalog, move_all_assets
 
 
 def create_move_assets_command(cli: click.Group) -> click.Command:
-
     @cli.command(
-        'move-assets',
-        short_help='Move or copy assets in a STAC to the Item locations.')
-    @click.argument('catalog_path')
-    @click.option('-c',
-                  '--copy',
-                  help='Copy assets instead of moving.',
-                  is_flag=True)
-    @click.option('-s',
-                  '--asset-subdirectory',
-                  help=('Subdirectory to place assets '
-                        'inside of the directory containing '
-                        'their items'))
-    def move_assets_command(catalog_path: str, copy: bool,
-                            asset_subdirectory: str) -> None:
+        "move-assets", short_help="Move or copy assets in a STAC to the Item locations."
+    )
+    @click.argument("catalog_path")
+    @click.option("-c", "--copy", help="Copy assets instead of moving.", is_flag=True)
+    @click.option(
+        "-s",
+        "--asset-subdirectory",
+        help=(
+            "Subdirectory to place assets "
+            "inside of the directory containing "
+            "their items"
+        ),
+    )
+    def move_assets_command(
+        catalog_path: str, copy: bool, asset_subdirectory: str
+    ) -> None:
         """Move or copy assets in a STAC Catalog.
 
         For all assets in the catalog at CATALOG_PATH, move or copy
@@ -36,12 +37,11 @@ def create_move_assets_command(cli: click.Group) -> click.Command:
         """
         catalog = pystac.read_file(catalog_path)
         if not isinstance(catalog, pystac.Catalog):
-            raise click.BadArgumentUsage(
-                f"{catalog_path} is not a STAC Catalog")
+            raise click.BadArgumentUsage(f"{catalog_path} is not a STAC Catalog")
 
-        processed = move_all_assets(catalog,
-                                    asset_subdirectory=asset_subdirectory,
-                                    copy=copy)
+        processed = move_all_assets(
+            catalog, asset_subdirectory=asset_subdirectory, copy=copy
+        )
 
         processed.save()
 
@@ -49,30 +49,42 @@ def create_move_assets_command(cli: click.Group) -> click.Command:
 
 
 def create_copy_command(cli: click.Group) -> click.Command:
-
-    @cli.command('copy', short_help='Copy a STAC Catalog')
-    @click.argument('src')
-    @click.argument('dst')
-    @click.option('-t',
-                  '--catalog-type',
-                  type=click.Choice([
-                      pystac.CatalogType.ABSOLUTE_PUBLISHED,
-                      pystac.CatalogType.RELATIVE_PUBLISHED,
-                      pystac.CatalogType.SELF_CONTAINED
-                  ],
-                                    case_sensitive=False))
-    @click.option('--copy-assets',
-                  '-a',
-                  is_flag=True,
-                  help=('Copy all item assets to '
-                        'be alongside the new item location.'))
-    @click.option('-l',
-                  '--publish-location',
-                  help=('Location to use for resolving HREF links '
-                        'instead of the destination folder.'))
-    def copy_command(src: str, dst: str, catalog_type: pystac.CatalogType,
-                     copy_assets: bool,
-                     publish_location: Optional[str]) -> None:
+    @cli.command("copy", short_help="Copy a STAC Catalog")
+    @click.argument("src")
+    @click.argument("dst")
+    @click.option(
+        "-t",
+        "--catalog-type",
+        type=click.Choice(
+            [
+                pystac.CatalogType.ABSOLUTE_PUBLISHED,
+                pystac.CatalogType.RELATIVE_PUBLISHED,
+                pystac.CatalogType.SELF_CONTAINED,
+            ],
+            case_sensitive=False,
+        ),
+    )
+    @click.option(
+        "--copy-assets",
+        "-a",
+        is_flag=True,
+        help=("Copy all item assets to " "be alongside the new item location."),
+    )
+    @click.option(
+        "-l",
+        "--publish-location",
+        help=(
+            "Location to use for resolving HREF links "
+            "instead of the destination folder."
+        ),
+    )
+    def copy_command(
+        src: str,
+        dst: str,
+        catalog_type: pystac.CatalogType,
+        copy_assets: bool,
+        publish_location: Optional[str],
+    ) -> None:
         """Copy a STAC Catalog or Collection at SRC to the directory
         at DST.
 
@@ -80,7 +92,6 @@ def create_copy_command(cli: click.Group) -> click.Command:
         source_catalog = pystac.read_file(make_absolute_href(src))
         if not isinstance(source_catalog, pystac.Catalog):
             raise click.BadArgumentUsage(f"{src} is not a STAC Catalog")
-        copy_catalog(source_catalog, dst, catalog_type, copy_assets,
-                     publish_location)
+        copy_catalog(source_catalog, dst, catalog_type, copy_assets, publish_location)
 
     return copy_command

--- a/src/stactools/cli/commands/create.py
+++ b/src/stactools/cli/commands/create.py
@@ -4,9 +4,8 @@ from stactools.core import create
 
 
 def create_create_item_command(cli: click.Group) -> click.Command:
-
-    @cli.command('create-item', short_help='Creates an item from an asset')
-    @click.argument('href')
+    @cli.command("create-item", short_help="Creates an item from an asset")
+    @click.argument("href")
     def create_item_command(href: str) -> None:
         """Creates an Item from a href.
 

--- a/src/stactools/cli/commands/info.py
+++ b/src/stactools/cli/commands/info.py
@@ -29,31 +29,23 @@ def print_info(catalog_path: str, skip_items: bool = False) -> None:
                     for ext in item.stac_extensions:
                         item_ext.add(ext)
 
-    cat_id_info = 'Catalog ID: {}'.format(cat.id)
-    cat_ext_info = '(extensions: {})'.format(
-        ','.join(cat_ext)) if cat_ext else ''
-    col_ext_info = '(extensions: {})'.format(
-        ','.join(col_ext)) if col_ext else ''
-    item_ext_info = '(extensions: {})'.format(
-        ','.join(item_ext)) if item_ext else ''
+    cat_id_info = "Catalog ID: {}".format(cat.id)
+    cat_ext_info = "(extensions: {})".format(",".join(cat_ext)) if cat_ext else ""
+    col_ext_info = "(extensions: {})".format(",".join(col_ext)) if col_ext else ""
+    item_ext_info = "(extensions: {})".format(",".join(item_ext)) if item_ext else ""
 
     print(cat_id_info)
-    print('-' * len(cat_id_info))
-    print('   CATALOGS: {} {}'.format(cat_count, cat_ext_info))
-    print('COLLECTIONS: {} {}'.format(col_count, col_ext_info))
+    print("-" * len(cat_id_info))
+    print("   CATALOGS: {} {}".format(cat_count, cat_ext_info))
+    print("COLLECTIONS: {} {}".format(col_count, col_ext_info))
     if not skip_items:
-        print('      ITEMS: {} {}'.format(item_count, item_ext_info))
+        print("      ITEMS: {} {}".format(item_count, item_ext_info))
 
 
 def create_info_command(cli: click.Group) -> click.Command:
-
-    @cli.command('info',
-                 short_help='Display info about a static STAC catalog.')
-    @click.argument('catalog_path')
-    @click.option('-s',
-                  '--skip_items',
-                  is_flag=True,
-                  help='Skip counting items')
+    @cli.command("info", short_help="Display info about a static STAC catalog.")
+    @click.argument("catalog_path")
+    @click.option("-s", "--skip_items", is_flag=True, help="Skip counting items")
     def info_command(catalog_path: str, skip_items: bool) -> None:
         print_info(catalog_path, skip_items)
 
@@ -61,16 +53,15 @@ def create_info_command(cli: click.Group) -> click.Command:
 
 
 def create_describe_command(cli: click.Group) -> click.Command:
-
     @cli.command(
-        'describe',
-        short_help='Prints out a list of all catalogs, collections and items '
-        'in this STAC.')
-    @click.argument('catalog_path')
-    @click.option('-h',
-                  '--include-hrefs',
-                  is_flag=True,
-                  help='Include HREFs in description.')
+        "describe",
+        short_help="Prints out a list of all catalogs, collections and items "
+        "in this STAC.",
+    )
+    @click.argument("catalog_path")
+    @click.option(
+        "-h", "--include-hrefs", is_flag=True, help="Include HREFs in description."
+    )
     def describe_command(catalog_path: str, include_hrefs: bool) -> None:
         cat = pystac.read_file(catalog_path)
         if not isinstance(cat, pystac.Catalog):

--- a/src/stactools/cli/commands/layout.py
+++ b/src/stactools/cli/commands/layout.py
@@ -5,43 +5,54 @@ from stactools.core import layout_catalog
 
 
 def create_layout_command(cli: click.Group) -> click.Command:
-
     @cli.command(
-        'layout',
-        short_help='Reformat the layout of a STAC based on templating.')
-    @click.argument('catalog')
-    @click.argument('item_path_template')
-    @click.option(
-        '-s',
-        '--create-subcatalogs',
-        is_flag=True,
-        help=('Create subcatalogs based on the template values instead of '
-              'just creating directories.'))
-    @click.option(
-        '-k',
-        '--remove-existing-subcatalogs',
-        is_flag=True,
-        help=('If this flag is set, existing subcatalogs will be'
-              'removed. If --create_subcatalogs is used, all items'
-              'will be places in the new subcatalogs from the source_catalog.')
+        "layout", short_help="Reformat the layout of a STAC based on templating."
     )
-    @click.option('-a',
-                  '--move-assets',
-                  is_flag=True,
-                  help='Move assets to the target catalog Item locations.')
-    def layout_command(catalog: str, item_path_template: str,
-                       create_subcatalogs: bool,
-                       remove_existing_subcatalogs: bool,
-                       move_assets: bool) -> None:
+    @click.argument("catalog")
+    @click.argument("item_path_template")
+    @click.option(
+        "-s",
+        "--create-subcatalogs",
+        is_flag=True,
+        help=(
+            "Create subcatalogs based on the template values instead of "
+            "just creating directories."
+        ),
+    )
+    @click.option(
+        "-k",
+        "--remove-existing-subcatalogs",
+        is_flag=True,
+        help=(
+            "If this flag is set, existing subcatalogs will be"
+            "removed. If --create_subcatalogs is used, all items"
+            "will be places in the new subcatalogs from the source_catalog."
+        ),
+    )
+    @click.option(
+        "-a",
+        "--move-assets",
+        is_flag=True,
+        help="Move assets to the target catalog Item locations.",
+    )
+    def layout_command(
+        catalog: str,
+        item_path_template: str,
+        create_subcatalogs: bool,
+        remove_existing_subcatalogs: bool,
+        move_assets: bool,
+    ) -> None:
         source = pystac.read_file(catalog)
         if not isinstance(source, pystac.Catalog):
             raise click.BadArgumentUsage(f"{catalog} is not a STAC Catalog")
 
-        layout_catalog(source,
-                       item_path_template,
-                       create_subcatalogs=create_subcatalogs,
-                       remove_existing_subcatalogs=remove_existing_subcatalogs,
-                       move_assets=move_assets)
+        layout_catalog(
+            source,
+            item_path_template,
+            create_subcatalogs=create_subcatalogs,
+            remove_existing_subcatalogs=remove_existing_subcatalogs,
+            move_assets=move_assets,
+        )
 
         source.save()
 

--- a/src/stactools/cli/commands/lint.py
+++ b/src/stactools/cli/commands/lint.py
@@ -4,11 +4,10 @@ from stac_check.lint import Linter  # type: ignore
 
 
 def create_lint_command(cli: click.Group) -> click.Command:
-
     @cli.command("lint", short_help="Lint a stac object with stac-check.")
-    @click.option("--quiet",
-                  is_flag=True,
-                  help=("Do not display the Ok no warnings message."))
+    @click.option(
+        "--quiet", is_flag=True, help=("Do not display the Ok no warnings message.")
+    )
     @click.argument("href")
     def lint_command(href: str, quiet: bool) -> None:
         """Lint a STAC object via stac-check.

--- a/src/stactools/cli/commands/merge.py
+++ b/src/stactools/cli/commands/merge.py
@@ -5,13 +5,15 @@ from typing import Optional
 from stactools.core import merge_all_items
 
 
-def merge(source_catalog: str,
-          target_catalog: str,
-          collection_id: Optional[str] = None,
-          move_assets: bool = False,
-          ignore_conflicts: bool = False,
-          as_child: bool = False,
-          child_folder: Optional[str] = None) -> None:
+def merge(
+    source_catalog: str,
+    target_catalog: str,
+    collection_id: Optional[str] = None,
+    move_assets: bool = False,
+    ignore_conflicts: bool = False,
+    as_child: bool = False,
+    child_folder: Optional[str] = None,
+) -> None:
     source = pystac.read_file(source_catalog)
     if not isinstance(source, pystac.Catalog):
         raise click.BadArgumentUsage(f"{source_catalog} is not a STAC Catalog")
@@ -24,54 +26,77 @@ def merge(source_catalog: str,
         target_new = target.get_child(collection_id, recursive=True)
         if target_new is None:
             raise click.BadOptionUsage(
-                'collection',
-                'A collection with ID {} does not exist in {}'.format(
-                    collection_id, target_catalog))
+                "collection",
+                "A collection with ID {} does not exist in {}".format(
+                    collection_id, target_catalog
+                ),
+            )
         target = target_new
-    merge_all_items(source, target, move_assets, ignore_conflicts, as_child,
-                    child_folder)
+    merge_all_items(
+        source, target, move_assets, ignore_conflicts, as_child, child_folder
+    )
 
     target.save()
 
 
 def create_merge_command(cli: click.Group) -> click.Command:
-
-    @cli.command('merge', short_help='Merge items from one STAC into another.')
-    @click.argument('source_catalog')
-    @click.argument('target_catalog')
-    @click.option('--collection',
-                  help=("The collection ID to merge into. If not set, will "
-                        "merge into the root catalog or collection."))
-    @click.option('-a',
-                  '--move-assets',
-                  is_flag=True,
-                  help='Move assets to the target catalog Item locations.')
+    @cli.command("merge", short_help="Merge items from one STAC into another.")
+    @click.argument("source_catalog")
+    @click.argument("target_catalog")
     @click.option(
-        '--ignore-conflicts',
-        is_flag=True,
-        help=('If there are conflicts with an item in both catalogs having '
-              'the same asset key, do not error, leave the original asset '
-              'from the target catalog in place.'))
+        "--collection",
+        help=(
+            "The collection ID to merge into. If not set, will "
+            "merge into the root catalog or collection."
+        ),
+    )
     @click.option(
-        '-c',
-        '--as-child',
+        "-a",
+        "--move-assets",
         is_flag=True,
-        help='Merge as child catalog of destination catalog or collection')
-    @click.option('-f',
-                  '--child-folder',
-                  help=('The subfolder name to copy to if the option to merge '
-                        'as a child is used. If not provided, the catalog id '
-                        'will be used'))
-    def merge_command(source_catalog: str, target_catalog: str,
-                      collection: str, move_assets: bool,
-                      ignore_conflicts: bool, as_child: bool,
-                      child_folder: str) -> None:
-        merge(source_catalog,
-              target_catalog,
-              collection_id=collection,
-              move_assets=move_assets,
-              ignore_conflicts=ignore_conflicts,
-              as_child=as_child,
-              child_folder=child_folder)
+        help="Move assets to the target catalog Item locations.",
+    )
+    @click.option(
+        "--ignore-conflicts",
+        is_flag=True,
+        help=(
+            "If there are conflicts with an item in both catalogs having "
+            "the same asset key, do not error, leave the original asset "
+            "from the target catalog in place."
+        ),
+    )
+    @click.option(
+        "-c",
+        "--as-child",
+        is_flag=True,
+        help="Merge as child catalog of destination catalog or collection",
+    )
+    @click.option(
+        "-f",
+        "--child-folder",
+        help=(
+            "The subfolder name to copy to if the option to merge "
+            "as a child is used. If not provided, the catalog id "
+            "will be used"
+        ),
+    )
+    def merge_command(
+        source_catalog: str,
+        target_catalog: str,
+        collection: str,
+        move_assets: bool,
+        ignore_conflicts: bool,
+        as_child: bool,
+        child_folder: str,
+    ) -> None:
+        merge(
+            source_catalog,
+            target_catalog,
+            collection_id=collection,
+            move_assets=move_assets,
+            ignore_conflicts=ignore_conflicts,
+            as_child=as_child,
+            child_folder=child_folder,
+        )
 
     return merge_command

--- a/src/stactools/cli/commands/migrate.py
+++ b/src/stactools/cli/commands/migrate.py
@@ -7,9 +7,8 @@ def migrate(option: click.Option) -> None:
 
 
 def create_migrate_command(cli: click.Group) -> click.Command:
-
-    @cli.command('migrate', short_help='Migrate a STAC catalog (TODO)')
-    @click.option('--option', '-o', default=1, help='A test option')
+    @cli.command("migrate", short_help="Migrate a STAC catalog (TODO)")
+    @click.option("--option", "-o", default=1, help="A test option")
     def migrate_command(option: click.Option) -> None:
         migrate(option)
 

--- a/src/stactools/cli/commands/validate.py
+++ b/src/stactools/cli/commands/validate.py
@@ -9,22 +9,27 @@ from stactools.core.utils import href_exists
 
 
 def create_validate_command(cli: click.Group) -> click.Command:
-
     @cli.command("validate", short_help="Validate a stac object.")
     @click.argument("href")
-    @click.option("--recurse/--no-recurse",
-                  default=True,
-                  help=("If false, do not validate any children "
-                        "(only useful for Catalogs and Collections"))
-    @click.option("--links/--no-links",
-                  default=True,
-                  help=("If false, do not check any of the objects's links."))
+    @click.option(
+        "--recurse/--no-recurse",
+        default=True,
+        help=(
+            "If false, do not validate any children "
+            "(only useful for Catalogs and Collections"
+        ),
+    )
+    @click.option(
+        "--links/--no-links",
+        default=True,
+        help=("If false, do not check any of the objects's links."),
+    )
     @click.option(
         "--assets/--no-assets",
         default=True,
-        help=("If false, do not check any of the collection's/item's assets."))
-    def validate_command(href: str, recurse: bool, links: bool,
-                         assets: bool) -> None:
+        help=("If false, do not check any of the collection's/item's assets."),
+    )
+    def validate_command(href: str, recurse: bool, links: bool, assets: bool) -> None:
         """Validates a STAC object.
 
         Prints any validation errors to stdout.
@@ -48,8 +53,13 @@ def create_validate_command(cli: click.Group) -> click.Command:
     return validate_command
 
 
-def validate(object: STACObject, root: Optional[STACObject], recurse: bool,
-             links: bool, assets: bool) -> List[str]:
+def validate(
+    object: STACObject,
+    root: Optional[STACObject],
+    recurse: bool,
+    links: bool,
+    assets: bool,
+) -> List[str]:
     errors: List[str] = []
 
     try:
@@ -65,7 +75,7 @@ def validate(object: STACObject, root: Optional[STACObject], recurse: bool,
             assert href
             if not href_exists(href):
                 errors.append(
-                    f"Missing link in {object.self_href}: \"{link.rel}\" -> {link.href}"
+                    f'Missing link in {object.self_href}: "{link.rel}" -> {link.href}'
                 )
 
     if assets and (isinstance(object, Item) or isinstance(object, Collection)):

--- a/src/stactools/cli/commands/version.py
+++ b/src/stactools/cli/commands/version.py
@@ -8,11 +8,9 @@ from click.core import Command, Group
 
 
 def create_version_command(cli: Group) -> Command:
-
-    @cli.command('version', short_help='Display version info.')
+    @cli.command("version", short_help="Display version info.")
     def version_command() -> None:
-        """Display version info
-        """
+        """Display version info"""
         echo(f"stactools version {__version__}")
         echo(f"PySTAC version {pystac.__version__}")
         echo(f"STAC version {get_stac_version()}")

--- a/src/stactools/cli/registry.py
+++ b/src/stactools/cli/registry.py
@@ -4,18 +4,18 @@ from typing import Callable, Iterator, List
 from click import Command, Group
 
 
-class Registry():
+class Registry:
     """A registry for resources that are built-in or contributed by plugins."""
 
     def __init__(self) -> None:
         self._create_command_functions: List[Callable[[Group], Command]] = []
 
     def register_subcommand(
-            self, create_command_function: Callable[[Group], Command]) -> None:
+        self, create_command_function: Callable[[Group], Command]
+    ) -> None:
         self._create_command_functions.append(create_command_function)
 
-    def get_create_subcommand_functions(
-            self) -> List[Callable[[Group], Command]]:
+    def get_create_subcommand_functions(self) -> List[Callable[[Group], Command]]:
         return self._create_command_functions[:]
 
     def load_plugins(self) -> None:
@@ -33,7 +33,7 @@ class Registry():
             # returned name an absolute name instead of a relative one. This allows
             # import_module to work without having to do additional modification to
             # the name.
-            return pkgutil.iter_modules(ns_pkg.__path__, ns_pkg.__name__ + '.')
+            return pkgutil.iter_modules(ns_pkg.__path__, ns_pkg.__name__ + ".")
 
         discovered_plugins = {
             name: importlib.import_module(name)
@@ -41,6 +41,6 @@ class Registry():
         }
 
         for name, module in discovered_plugins.items():
-            register_plugin = getattr(module, 'register_plugin', None)
+            register_plugin = getattr(module, "register_plugin", None)
             if register_plugin:
                 register_plugin(self)

--- a/src/stactools/core/__init__.py
+++ b/src/stactools/core/__init__.py
@@ -1,10 +1,14 @@
 # flake8: noqa
 
 from stactools.core.io import use_fsspec
-from stactools.core.copy import (move_asset_file_to_item, move_assets,
-                                 move_all_assets, copy_catalog)
+from stactools.core.copy import (
+    move_asset_file_to_item,
+    move_assets,
+    move_all_assets,
+    copy_catalog,
+)
 from stactools.core.layout import layout_catalog
-from stactools.core.merge import (merge_items, merge_all_items)
+from stactools.core.merge import merge_items, merge_all_items
 from stactools.core.add import add_item
 from stactools.core.addraster import add_raster_to_item
 

--- a/src/stactools/core/add.py
+++ b/src/stactools/core/add.py
@@ -6,9 +6,9 @@ from pystac.layout import BestPracticesLayoutStrategy
 from stactools.core.copy import move_assets as do_move_assets
 
 
-def add_item(source_item: Item,
-             target_catalog: Catalog,
-             move_assets: bool = False) -> None:
+def add_item(
+    source_item: Item, target_catalog: Catalog, move_assets: bool = False
+) -> None:
     """Add a item into a catalog.
 
     Args:
@@ -22,15 +22,14 @@ def add_item(source_item: Item,
     target_item_ids = [item.id for item in target_catalog.get_all_items()]
     if source_item.id in target_item_ids:
         raise ValueError(
-            f'An item with ID {source_item.id} already exists in the target catalog'
+            f"An item with ID {source_item.id} already exists in the target catalog"
         )
     self_href = target_catalog.get_self_href()
     if self_href:
         parent_dir = os.path.dirname(self_href)
         layout_strategy = BestPracticesLayoutStrategy()
         item_copy = source_item.clone()
-        item_copy.set_self_href(
-            layout_strategy.get_item_href(item_copy, parent_dir))
+        item_copy.set_self_href(layout_strategy.get_item_href(item_copy, parent_dir))
         target_catalog.add_item(item_copy)
 
         if isinstance(target_catalog, Collection):

--- a/src/stactools/core/addraster.py
+++ b/src/stactools/core/addraster.py
@@ -4,8 +4,13 @@ from typing import List
 import numpy
 from pystac import Item
 from pystac.utils import make_absolute_href
-from pystac.extensions.raster import (DataType, Histogram, RasterBand,
-                                      RasterExtension, Statistics)
+from pystac.extensions.raster import (
+    DataType,
+    Histogram,
+    RasterBand,
+    RasterExtension,
+    Statistics,
+)
 import rasterio
 
 logger = logging.getLogger(__name__)
@@ -50,11 +55,12 @@ def _read_bands(href: str) -> List[RasterBand]:
             # `mypy.ini`.
             minimum = float(numpy.min(data))  # type: ignore
             maximum = float(numpy.max(data))  # type: ignore
-            band.statistics = Statistics.create(minimum=minimum,
-                                                maximum=maximum)
+            band.statistics = Statistics.create(minimum=minimum, maximum=maximum)
             hist_data, _ = numpy.histogram(  # type: ignore
-                data, range=(minimum, maximum), bins=BINS)
-            band.histogram = Histogram.create(BINS, minimum, maximum,
-                                              hist_data.tolist())
+                data, range=(minimum, maximum), bins=BINS
+            )
+            band.histogram = Histogram.create(
+                BINS, minimum, maximum, hist_data.tolist()
+            )
             bands.append(band)
     return bands

--- a/src/stactools/core/copy.py
+++ b/src/stactools/core/copy.py
@@ -6,18 +6,19 @@ from fsspec.core import split_protocol
 from fsspec.registry import get_filesystem_class
 
 from pystac import Catalog, CatalogType, Item
-from pystac.utils import (is_absolute_href, make_absolute_href,
-                          make_relative_href)
+from pystac.utils import is_absolute_href, make_absolute_href, make_relative_href
 from typing import Optional
 
 logger = logging.getLogger(__name__)
 
 
-def move_asset_file_to_item(item: Item,
-                            asset_href: str,
-                            asset_subdirectory: Optional[str] = None,
-                            copy: bool = False,
-                            ignore_conflicts: bool = False) -> str:
+def move_asset_file_to_item(
+    item: Item,
+    asset_href: str,
+    asset_subdirectory: Optional[str] = None,
+    copy: bool = False,
+    ignore_conflicts: bool = False,
+) -> str:
     """Moves an asset file to be alongside that item.
 
     Args:
@@ -39,10 +40,11 @@ def move_asset_file_to_item(item: Item,
     if item_href is None:
         raise ValueError(
             f"Self HREF is not available for item {item.id}. This operation "
-            "requires that the Item HREFs are available.")
+            "requires that the Item HREFs are available."
+        )
 
     if not is_absolute_href(asset_href):
-        raise ValueError('asset_href must be absolute.')
+        raise ValueError("asset_href must be absolute.")
 
     item_dir = os.path.dirname(item_href)
 
@@ -60,19 +62,18 @@ def move_asset_file_to_item(item: Item,
 
         if fs_dest.exists(new_asset_href):
             if not ignore_conflicts:
-                raise FileExistsError(
-                    '{} already exists'.format(new_asset_href))
+                raise FileExistsError("{} already exists".format(new_asset_href))
         else:
             if copy:
 
                 def _op1(dry_run: bool = False) -> None:
-                    logger.info("Copying {} to {}...".format(
-                        asset_href, new_asset_href))
+                    logger.info(
+                        "Copying {} to {}...".format(asset_href, new_asset_href)
+                    )
                     if not dry_run:
-                        fs_dest.makedirs(os.path.dirname(new_asset_href),
-                                         exist_ok=True)
-                        with fsspec.open(asset_href, 'rb') as f_src:
-                            with fsspec.open(new_asset_href, 'wb') as f_dst:
+                        fs_dest.makedirs(os.path.dirname(new_asset_href), exist_ok=True)
+                        with fsspec.open(asset_href, "rb") as f_src:
+                            with fsspec.open(new_asset_href, "wb") as f_dst:
                                 f_dst.write(f_src.read())
 
                 op = _op1
@@ -82,26 +83,29 @@ def move_asset_file_to_item(item: Item,
                 if source_protocol == dest_protocol:
 
                     def _op2(dry_run: bool = False) -> None:
-                        logger.info("Moving {} to {}...".format(
-                            asset_href, new_asset_href))
+                        logger.info(
+                            "Moving {} to {}...".format(asset_href, new_asset_href)
+                        )
                         if not dry_run:
-                            fs_dest.makedirs(os.path.dirname(new_asset_href),
-                                             exist_ok=True)
+                            fs_dest.makedirs(
+                                os.path.dirname(new_asset_href), exist_ok=True
+                            )
                             fs_dest.move(asset_href, new_asset_href)
 
                     op = _op2
                 else:
 
                     def _op3(dry_run: bool = False) -> None:
-                        logger.info("Moving {} to {}...".format(
-                            asset_href, new_asset_href))
+                        logger.info(
+                            "Moving {} to {}...".format(asset_href, new_asset_href)
+                        )
                         if not dry_run:
                             fs_source = get_filesystem_class(source_protocol)()
-                            fs_dest.makedirs(os.path.dirname(new_asset_href),
-                                             exist_ok=True)
-                            with fsspec.open(asset_href, 'rb') as f_src:
-                                with fsspec.open(new_asset_href,
-                                                 'wb') as f_dst:
+                            fs_dest.makedirs(
+                                os.path.dirname(new_asset_href), exist_ok=True
+                            )
+                            with fsspec.open(asset_href, "rb") as f_src:
+                                with fsspec.open(new_asset_href, "wb") as f_dst:
                                     f_dst.write(f_src.read())
                             fs_source.delete(asset_href)
 
@@ -113,11 +117,13 @@ def move_asset_file_to_item(item: Item,
     return new_asset_href
 
 
-def move_assets(item: Item,
-                asset_subdirectory: Optional[str] = None,
-                make_hrefs_relative: bool = True,
-                copy: bool = False,
-                ignore_conflicts: bool = False) -> Item:
+def move_assets(
+    item: Item,
+    asset_subdirectory: Optional[str] = None,
+    make_hrefs_relative: bool = True,
+    copy: bool = False,
+    ignore_conflicts: bool = False,
+) -> Item:
     """Moves assets for an item to be alongside that item.
 
     Args:
@@ -141,21 +147,24 @@ def move_assets(item: Item,
     if item_href is None:
         raise ValueError(
             f"Self HREF is not available for item {item.id}. This operation "
-            "requires that the Item HREFs are available.")
+            "requires that the Item HREFs are available."
+        )
 
     for asset in item.assets.values():
         abs_asset_href = asset.get_absolute_href()
         if abs_asset_href is None:
             raise ValueError(
                 f"Asset {asset.title} HREF is not available for item {item.id}. This operation "
-                "requires that the Asset HREFs are available.")
+                "requires that the Asset HREFs are available."
+            )
 
         new_asset_href = move_asset_file_to_item(
             item,
             abs_asset_href,
             asset_subdirectory=asset_subdirectory,
             copy=copy,
-            ignore_conflicts=ignore_conflicts)
+            ignore_conflicts=ignore_conflicts,
+        )
 
         if make_hrefs_relative:
             asset.href = make_relative_href(new_asset_href, item_href)
@@ -165,11 +174,13 @@ def move_assets(item: Item,
     return item
 
 
-def move_all_assets(catalog: Catalog,
-                    asset_subdirectory: Optional[str] = None,
-                    make_hrefs_relative: bool = True,
-                    copy: bool = False,
-                    ignore_conflicts: bool = False) -> Catalog:
+def move_all_assets(
+    catalog: Catalog,
+    asset_subdirectory: Optional[str] = None,
+    make_hrefs_relative: bool = True,
+    copy: bool = False,
+    ignore_conflicts: bool = False,
+) -> Catalog:
     """Moves assets in a catalog to be alongside the items that own them.
 
     Args:
@@ -191,17 +202,20 @@ def move_all_assets(catalog: Catalog,
     """
 
     for item in catalog.get_all_items():
-        move_assets(item, asset_subdirectory, make_hrefs_relative, copy,
-                    ignore_conflicts)
+        move_assets(
+            item, asset_subdirectory, make_hrefs_relative, copy, ignore_conflicts
+        )
 
     return catalog
 
 
-def copy_catalog(source_catalog: Catalog,
-                 dest_directory: str,
-                 catalog_type: Optional[CatalogType] = None,
-                 copy_assets: bool = False,
-                 publish_location: Optional[str] = None) -> None:
+def copy_catalog(
+    source_catalog: Catalog,
+    dest_directory: str,
+    catalog_type: Optional[CatalogType] = None,
+    copy_assets: bool = False,
+    publish_location: Optional[str] = None,
+) -> None:
     catalog = source_catalog.full_copy()
     dest_directory = make_absolute_href(dest_directory)
 

--- a/src/stactools/core/create.py
+++ b/src/stactools/core/create.py
@@ -11,8 +11,7 @@ import stactools.core.projection
 from .io import ReadHrefModifier
 
 
-def item(href: str,
-         read_href_modifier: Optional[ReadHrefModifier] = None) -> Item:
+def item(href: str, read_href_modifier: Optional[ReadHrefModifier] = None) -> Item:
     """Creates a STAC Item from the asset at the provided href.
 
     The `read_href_modifer` argument can be used to modify the href for the
@@ -47,26 +46,27 @@ def item(href: str,
         proj_transform = list(dataset.transform)[0:6]
         proj_shape = dataset.shape
     proj_geometry = shapely.geometry.mapping(shapely.geometry.box(*proj_bbox))
-    geometry = stactools.core.projection.reproject_geom(crs,
-                                                        'EPSG:4326',
-                                                        proj_geometry,
-                                                        precision=6)
+    geometry = stactools.core.projection.reproject_geom(
+        crs, "EPSG:4326", proj_geometry, precision=6
+    )
     bbox = list(shapely.geometry.shape(geometry).bounds)
-    item = Item(id=id,
-                geometry=geometry,
-                bbox=bbox,
-                datetime=datetime.datetime.now(),
-                properties={})
+    item = Item(
+        id=id,
+        geometry=geometry,
+        bbox=bbox,
+        datetime=datetime.datetime.now(),
+        properties={},
+    )
 
     projection = ProjectionExtension.ext(item, add_if_missing=True)
     epsg = crs.to_epsg()
     if epsg:
         projection.epsg = epsg
     else:
-        projection.wkt2 = crs.to_wkt('WKT2')
+        projection.wkt2 = crs.to_wkt("WKT2")
     projection.transform = proj_transform
     projection.shape = proj_shape
 
-    item.add_asset('data', Asset(href=href, roles=['data']))
+    item.add_asset("data", Asset(href=href, roles=["data"]))
 
     return item

--- a/src/stactools/core/io/__init__.py
+++ b/src/stactools/core/io/__init__.py
@@ -11,8 +11,7 @@ to a signed URL
 """
 
 
-def read_text(href: str,
-              read_href_modifier: Optional[ReadHrefModifier] = None) -> str:
+def read_text(href: str, read_href_modifier: Optional[ReadHrefModifier] = None) -> str:
     if read_href_modifier is None:
         return StacIO.default().read_text(href)
     else:
@@ -20,20 +19,19 @@ def read_text(href: str,
 
 
 class FsspecStacIO(DefaultStacIO):
-
     def read_text_from_href(self, href: str, *args: Any, **kwargs: Any) -> str:
         with fsspec.open(href, "r") as f:
             s = f.read()
             if isinstance(s, str):
                 return s
             elif isinstance(s, bytes):
-                return str(s, encoding='utf-8')
+                return str(s, encoding="utf-8")
             else:
-                raise ValueError(
-                    f"Unable to decode data loaded from HREF: {href}")
+                raise ValueError(f"Unable to decode data loaded from HREF: {href}")
 
-    def write_text_from_href(self, href: str, txt: str, *args: Any,
-                             **kwargs: Any) -> None:
+    def write_text_from_href(
+        self, href: str, txt: str, *args: Any, **kwargs: Any
+    ) -> None:
         with fsspec.open(href, "w") as destination:
             destination.write(txt)
 

--- a/src/stactools/core/io/xml.py
+++ b/src/stactools/core/io/xml.py
@@ -21,8 +21,8 @@ class XmlElement:
         return None if node is None else XmlElement(node)
 
     def find_or_throw(
-            self, xpath: str,
-            get_exception: Callable[[str], Exception]) -> "XmlElement":
+        self, xpath: str, get_exception: Callable[[str], Exception]
+    ) -> "XmlElement":
         result = self.find(xpath)
         if result is None:
             raise get_exception(xpath)
@@ -31,8 +31,8 @@ class XmlElement:
     @lru_cache(maxsize=100)
     def findall(self, xpath: str) -> List["XmlElement"]:
         return [
-            XmlElement(e) for e in self.element.findall(
-                xpath, self.element.nsmap)  # type: ignore
+            XmlElement(e)
+            for e in self.element.findall(xpath, self.element.nsmap)  # type: ignore
         ]
 
     @lru_cache(maxsize=100)
@@ -40,8 +40,9 @@ class XmlElement:
         node = self.find(xpath)
         return None if node is None else node.text
 
-    def find_text_or_throw(self, xpath: str,
-                           get_exception: Callable[[str], Exception]) -> str:
+    def find_text_or_throw(
+        self, xpath: str, get_exception: Callable[[str], Exception]
+    ) -> str:
         result = self.find_text(xpath)
         if result is None:
             raise get_exception(xpath)
@@ -57,7 +58,7 @@ class XmlElement:
         if isinstance(self.element.text, str):
             return self.element.text
         elif isinstance(self.element.text, bytes):
-            return str(self.element.text, encoding='utf-8')
+            return str(self.element.text, encoding="utf-8")
         else:
             assert self.element.text is None
             return None
@@ -67,9 +68,8 @@ class XmlElement:
         return self.element.get(attr, None)
 
     @classmethod
-    def from_file(cls,
-                  href: str,
-                  read_href_modifier: Optional[ReadHrefModifier] = None
-                  ) -> "XmlElement":
+    def from_file(
+        cls, href: str, read_href_modifier: Optional[ReadHrefModifier] = None
+    ) -> "XmlElement":
         text = read_text(href, read_href_modifier)
-        return cls(etree.fromstring(bytes(text, encoding='utf-8')))
+        return cls(etree.fromstring(bytes(text, encoding="utf-8")))

--- a/src/stactools/core/layout.py
+++ b/src/stactools/core/layout.py
@@ -6,11 +6,13 @@ from pystac.layout import TemplateLayoutStrategy
 from stactools.core import move_all_assets
 
 
-def layout_catalog(catalog: Catalog,
-                   item_path_template: str,
-                   create_subcatalogs: bool = False,
-                   remove_existing_subcatalogs: bool = False,
-                   move_assets: bool = False) -> Catalog:
+def layout_catalog(
+    catalog: Catalog,
+    item_path_template: str,
+    create_subcatalogs: bool = False,
+    remove_existing_subcatalogs: bool = False,
+    move_assets: bool = False,
+) -> Catalog:
     """Modify the layout of a STAC.
 
     Given a catalog and a layout template, modify the layout of the STAC
@@ -52,8 +54,7 @@ def layout_catalog(catalog: Catalog,
         catalog.normalize_hrefs(os.path.dirname(catalog.self_href))
     else:
         strategy = TemplateLayoutStrategy(item_template=item_path_template)
-        catalog.normalize_hrefs(os.path.dirname(catalog.self_href),
-                                strategy=strategy)
+        catalog.normalize_hrefs(os.path.dirname(catalog.self_href), strategy=strategy)
 
     if move_assets:
         move_all_assets(catalog, ignore_conflicts=True)

--- a/src/stactools/core/projection.py
+++ b/src/stactools/core/projection.py
@@ -16,19 +16,17 @@ def epsg_from_utm_zone_number(utm_zone_number: int, south: bool) -> int:
     Returns:
         int: The EPSG code number for the UTM zone.
     """
-    crs = pyproj.CRS.from_dict({
-        'proj': 'utm',
-        'zone': utm_zone_number,
-        'south': south
-    })
+    crs = pyproj.CRS.from_dict({"proj": "utm", "zone": utm_zone_number, "south": south})
 
     return int(crs.to_authority()[1])
 
 
-def reproject_geom(src_crs: Union[pyproj.CRS, rasterio.crs.CRS, str],
-                   dest_crs: Union[pyproj.CRS, rasterio.crs.CRS, str],
-                   geom: Dict[str, Any],
-                   precision: Optional[int] = None) -> Dict[str, Any]:
+def reproject_geom(
+    src_crs: Union[pyproj.CRS, rasterio.crs.CRS, str],
+    dest_crs: Union[pyproj.CRS, rasterio.crs.CRS, str],
+    geom: Dict[str, Any],
+    precision: Optional[int] = None,
+) -> Dict[str, Any]:
     """Reprojects a geometry represented as GeoJSON
     from the src_crs to the dest crs.
 
@@ -43,9 +41,7 @@ def reproject_geom(src_crs: Union[pyproj.CRS, rasterio.crs.CRS, str],
     Returns:
         dict: The reprojected geometry
     """
-    transformer = pyproj.Transformer.from_crs(src_crs,
-                                              dest_crs,
-                                              always_xy=True)
+    transformer = pyproj.Transformer.from_crs(src_crs, dest_crs, always_xy=True)
     result = deepcopy(geom)
 
     def fn(coords: Sequence[Any]) -> Sequence[Any]:
@@ -64,7 +60,7 @@ def reproject_geom(src_crs: Union[pyproj.CRS, rasterio.crs.CRS, str],
                 coords[i] = reprojected_coords
         return coords
 
-    result['coordinates'] = fn(result['coordinates'])
+    result["coordinates"] = fn(result["coordinates"])
 
     return result
 
@@ -76,5 +72,7 @@ def transform_from_bbox(bbox: List[float], shape: List[int]) -> List[float]:
     Only take the first 6 elements, as that is all that is necessary.
     """
     return list(
-        rasterio.transform.from_bounds(bbox[0], bbox[1], bbox[2], bbox[3],
-                                       shape[1], shape[0]))[:6]
+        rasterio.transform.from_bounds(
+            bbox[0], bbox[1], bbox[2], bbox[3], shape[1], shape[0]
+        )
+    )[:6]

--- a/src/stactools/core/utils/__init__.py
+++ b/src/stactools/core/utils/__init__.py
@@ -3,8 +3,8 @@ from typing import Callable, Optional, TypeVar
 import fsspec
 import rasterio
 
-T = TypeVar('T')
-U = TypeVar('U')
+T = TypeVar("T")
+U = TypeVar("U")
 
 
 def map_opt(fn: Callable[[T], U], v: Optional[T]) -> Optional[U]:

--- a/src/stactools/core/utils/antimeridian.py
+++ b/src/stactools/core/utils/antimeridian.py
@@ -12,9 +12,10 @@ from shapely.geometry import Polygon, MultiPolygon, LineString
 class Strategy(Enum):
     """Strategy for handling antimeridian-crossing polygons.
 
-        - SPLIT: split the polygon at the antimeridian
-        - NORMALIZE: keep the polygon as one, but extend it to > 180 or < -180.
+    - SPLIT: split the polygon at the antimeridian
+    - NORMALIZE: keep the polygon as one, but extend it to > 180 or < -180.
     """
+
     SPLIT = auto()
     NORMALIZE = auto()
 

--- a/src/stactools/core/utils/convert.py
+++ b/src/stactools/core/utils/convert.py
@@ -13,9 +13,7 @@ DEFAULT_PROFILE = {
 }
 
 
-def cogify(infile: str,
-           outfile: str,
-           profile: Optional[Dict[str, Any]] = None) -> None:
+def cogify(infile: str, outfile: str, profile: Optional[Dict[str, Any]] = None) -> None:
     """Creates a COG from a GDAL-readable file."""
     if not utils.gdal_driver_is_enabled("COG"):
         raise DriverRegistrationError(

--- a/src/stactools/core/utils/subprocess.py
+++ b/src/stactools/core/utils/subprocess.py
@@ -6,10 +6,9 @@ logger = logging.getLogger(__name__)
 
 
 def call(command: List[str]) -> int:
-
     def log_subprocess_output(pipe: IO[bytes]) -> None:
-        for line in iter(pipe.readline, b''):  # b'\n'-separated lines
-            logger.info(line.decode("utf-8").strip('\n'))
+        for line in iter(pipe.readline, b""):  # b'\n'-separated lines
+            logger.info(line.decode("utf-8").strip("\n"))
 
     process = Popen(command, stdout=PIPE, stderr=STDOUT)
     if process.stdout:

--- a/src/stactools/testing/cli.py
+++ b/src/stactools/testing/cli.py
@@ -18,25 +18,26 @@ def cli() -> None:
 
 
 @cli.command("make-rasters-smaller")
-@click.option("--dir",
-              required=True,
-              help="Directory to walk and transform rasters.")
-@click.option("-n",
-              "--dry-run",
-              required=True,
-              help="Do a dry run; print commands.",
-              is_flag=True)
+@click.option("--dir", required=True, help="Directory to walk and transform rasters.")
+@click.option(
+    "-n", "--dry-run", required=True, help="Do a dry run; print commands.", is_flag=True
+)
 def make_rasters_smaller_cmd(dir: str, dry_run: bool) -> None:
-
     def make_it_smaller(tif_path: str) -> None:
         with TemporaryDirectory() as tmp_dir:
             tmp_path = os.path.join(tmp_dir, "smaller.tif")
             translate_cmd = [
-                "gdal_translate", "-of", "GTiff", "-outsize", "512", "512",
-                tif_path, tmp_path
+                "gdal_translate",
+                "-of",
+                "GTiff",
+                "-outsize",
+                "512",
+                "512",
+                tif_path,
+                tmp_path,
             ]
             if dry_run:
-                logger.info(' '.join(translate_cmd))
+                logger.info(" ".join(translate_cmd))
             else:
                 call(translate_cmd)
 
@@ -44,13 +45,13 @@ def make_rasters_smaller_cmd(dir: str, dry_run: bool) -> None:
 
     for root, _, files in os.walk(dir):
         for f in files:
-            if f.lower().endswith('.tif'):
+            if f.lower().endswith(".tif"):
                 full_path = os.path.join(root, f)
                 make_it_smaller(full_path)
 
 
 def run_cli() -> None:
-    cli(prog_name='testutils')
+    cli(prog_name="testutils")
 
 
 if __name__ == "__main__":

--- a/src/stactools/testing/cli_test.py
+++ b/src/stactools/testing/cli_test.py
@@ -1,4 +1,4 @@
-from abc import (ABC, abstractmethod)
+from abc import ABC, abstractmethod
 import logging
 from typing import List, Callable
 import unittest
@@ -8,20 +8,18 @@ from click.testing import CliRunner, Result
 
 
 class CliTestCase(unittest.TestCase, ABC):
-
     def use_debug_logging(self) -> None:
-        logger = logging.getLogger('stactools')
+        logger = logging.getLogger("stactools")
         logger.setLevel(logging.DEBUG)
 
         ch = logging.StreamHandler()
         ch.setLevel(logging.DEBUG)
-        formatter = logging.Formatter('%(message)s')
+        formatter = logging.Formatter("%(message)s")
         ch.setFormatter(formatter)
 
         logger.addHandler(ch)
 
     def setUp(self) -> None:
-
         @click.group()
         def cli() -> None:
             pass
@@ -39,6 +37,7 @@ class CliTestCase(unittest.TestCase, ABC):
 
     @abstractmethod
     def create_subcommand_functions(
-            self) -> List[Callable[[click.Group], click.Command]]:
+        self,
+    ) -> List[Callable[[click.Group], click.Command]]:
         """Return list of 'create_command' functions from implementations"""
         pass

--- a/src/stactools/testing/test_data.py
+++ b/src/stactools/testing/test_data.py
@@ -36,24 +36,23 @@ class TestData:
         self.external_data = external_data
 
     def get_path(self, rel_path: str) -> str:
-        return os.path.abspath(
-            os.path.join(os.path.dirname(self.path), rel_path))
+        return os.path.abspath(os.path.join(os.path.dirname(self.path), rel_path))
 
     def get_external_data(self, rel_path: str) -> str:
-        path = self.get_path(os.path.join('data-files/external', rel_path))
+        path = self.get_path(os.path.join("data-files/external", rel_path))
         if not os.path.exists(path):
             entry = self.external_data.get(rel_path)
             if entry is None:
-                raise Exception('Path {} does not exist and there is no entry '
-                                'for external test data {}.'.format(
-                                    path, rel_path))
+                raise Exception(
+                    "Path {} does not exist and there is no entry "
+                    "for external test data {}.".format(path, rel_path)
+                )
 
-            print('Downloading external test data {}...'.format(rel_path))
+            print("Downloading external test data {}...".format(rel_path))
             os.makedirs(os.path.dirname(path), exist_ok=True)
 
             s3_config = entry.get("s3")
-            is_pc = entry.get(
-                "planetary_computer")  # True if from PC, needs signing
+            is_pc = entry.get("planetary_computer")  # True if from PC, needs signing
             if s3_config:
                 try:
                     import s3fs
@@ -72,7 +71,8 @@ class TestData:
                 href = entry["url"]
                 r = requests.get(
                     "https://planetarycomputer.microsoft.com/api/sas/v1/sign?"
-                    f"href={href}")
+                    f"href={href}"
+                )
                 r.raise_for_status()
                 signed_href = r.json()["href"]
 
@@ -83,17 +83,17 @@ class TestData:
                 with fsspec.open(entry["url"]) as f:
                     data = f.read()
 
-            if entry.get("compress") == 'zip':
+            if entry.get("compress") == "zip":
                 with TemporaryDirectory() as tmp_dir:
-                    tmp_path = os.path.join(tmp_dir, 'file.zip')
-                    with open(tmp_path, 'wb') as f:
+                    tmp_path = os.path.join(tmp_dir, "file.zip")
+                    with open(tmp_path, "wb") as f:
                         f.write(data)
                     z = ZipFile(tmp_path)
                     name = z.namelist()[0]
                     extracted_path = z.extract(name)
                     shutil.move(extracted_path, path)
             else:
-                with open(path, 'wb') as f:
+                with open(path, "wb") as f:
                     f.write(data)
 
         return path

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -16,7 +16,7 @@ class Logging:
 
         ch = logging.StreamHandler()
         ch.setLevel(level)
-        formatter = logging.Formatter('%(message)s')
+        formatter = logging.Formatter("%(message)s")
         ch.setFormatter(formatter)
 
         logger.addHandler(ch)

--- a/tests/cli/commands/test_add.py
+++ b/tests/cli/commands/test_add.py
@@ -18,7 +18,6 @@ def create_temp_catalog_copy(tmp_dir):
 
 
 class AddTest(CliTestCase):
-
     def create_subcommand_functions(self):
         return [create_add_command]
 
@@ -88,5 +87,4 @@ class AddTest(CliTestCase):
 
             res = self.run_command(cmd)
             self.assertEqual(res.exit_code, 2)
-            self.assertTrue(
-                " A collection with ID WRONG does not exist" in res.output)
+            self.assertTrue(" A collection with ID WRONG does not exist" in res.output)

--- a/tests/cli/commands/test_addraster.py
+++ b/tests/cli/commands/test_addraster.py
@@ -20,7 +20,6 @@ def create_temp_catalog_copy(tmp_dir):
 
 
 class AddRasterTest(CliTestCase):
-
     def create_subcommand_functions(self):
         return [create_addraster_command]
 
@@ -28,8 +27,9 @@ class AddRasterTest(CliTestCase):
         with TemporaryDirectory() as tmp_dir:
             catalog = create_temp_catalog_copy(tmp_dir)
             items = list(catalog.get_all_items())
-            item_path = make_absolute_href(items[0].get_self_href(),
-                                           catalog.get_self_href())
+            item_path = make_absolute_href(
+                items[0].get_self_href(), catalog.get_self_href()
+            )
 
             cmd = ["addraster", item_path]
             self.run_command(cmd)

--- a/tests/cli/commands/test_cases.py
+++ b/tests/cli/commands/test_cases.py
@@ -2,66 +2,82 @@ import os
 from datetime import datetime
 
 import pystac
-from pystac import (Catalog, Item, Asset, Extent, TemporalExtent,
-                    SpatialExtent, MediaType)
-from pystac.extensions.label import (LabelOverview, LabelClasses, LabelCount,
-                                     LabelExtension, LabelType)
+from pystac import (
+    Catalog,
+    Item,
+    Asset,
+    Extent,
+    TemporalExtent,
+    SpatialExtent,
+    MediaType,
+)
+from pystac.extensions.label import (
+    LabelOverview,
+    LabelClasses,
+    LabelCount,
+    LabelExtension,
+    LabelType,
+)
 
 from tests import test_data
 
 TEST_LABEL_CATALOG = {
-    'country-1': {
-        'area-1-1': {
-            'dsm': 'area-1-1_dsm.tif',
-            'ortho': 'area-1-1_ortho.tif',
-            'labels': 'area-1-1_labels.geojson'
+    "country-1": {
+        "area-1-1": {
+            "dsm": "area-1-1_dsm.tif",
+            "ortho": "area-1-1_ortho.tif",
+            "labels": "area-1-1_labels.geojson",
         },
-        'area-1-2': {
-            'dsm': 'area-1-2_dsm.tif',
-            'ortho': 'area-1-2_ortho.tif',
-            'labels': 'area-1-2_labels.geojson'
-        }
+        "area-1-2": {
+            "dsm": "area-1-2_dsm.tif",
+            "ortho": "area-1-2_ortho.tif",
+            "labels": "area-1-2_labels.geojson",
+        },
     },
-    'country-2': {
-        'area-2-1': {
-            'dsm': 'area-2-1_dsm.tif',
-            'ortho': 'area-2-1_ortho.tif',
-            'labels': 'area-2-1_labels.geojson'
+    "country-2": {
+        "area-2-1": {
+            "dsm": "area-2-1_dsm.tif",
+            "ortho": "area-2-1_ortho.tif",
+            "labels": "area-2-1_labels.geojson",
         },
-        'area-2-2': {
-            'dsm': 'area-2-2_dsm.tif',
-            'ortho': 'area-2-2_ortho.tif',
-            'labels': 'area-2-2_labels.geojson'
-        }
-    }
+        "area-2-2": {
+            "dsm": "area-2-2_dsm.tif",
+            "ortho": "area-2-2_ortho.tif",
+            "labels": "area-2-2_labels.geojson",
+        },
+    },
 }
 
 RANDOM_GEOM = {
-    "type":
-    "Polygon",
-    "coordinates": [[[-2.5048828125, 3.8916575492899987],
-                     [-1.9610595703125, 3.8916575492899987],
-                     [-1.9610595703125, 4.275202171119132],
-                     [-2.5048828125, 4.275202171119132],
-                     [-2.5048828125, 3.8916575492899987]]]
+    "type": "Polygon",
+    "coordinates": [
+        [
+            [-2.5048828125, 3.8916575492899987],
+            [-1.9610595703125, 3.8916575492899987],
+            [-1.9610595703125, 4.275202171119132],
+            [-2.5048828125, 4.275202171119132],
+            [-2.5048828125, 3.8916575492899987],
+        ]
+    ],
 }
 
 RANDOM_BBOX = [
-    RANDOM_GEOM['coordinates'][0][0][0], RANDOM_GEOM['coordinates'][0][0][1],
-    RANDOM_GEOM['coordinates'][0][1][0], RANDOM_GEOM['coordinates'][0][1][1]
+    RANDOM_GEOM["coordinates"][0][0][0],
+    RANDOM_GEOM["coordinates"][0][0][1],
+    RANDOM_GEOM["coordinates"][0][1][0],
+    RANDOM_GEOM["coordinates"][0][1][1],
 ]
 
-RANDOM_EXTENT = Extent(spatial=SpatialExtent.from_coordinates(
-    RANDOM_GEOM['coordinates']),
-                       temporal=TemporalExtent.from_now())  # noqa: E126
+RANDOM_EXTENT = Extent(
+    spatial=SpatialExtent.from_coordinates(RANDOM_GEOM["coordinates"]),
+    temporal=TemporalExtent.from_now(),
+)  # noqa: E126
 
 
 class TestCases:
-
     @staticmethod
     def get_path(rel_path):
-        return os.path.abspath(
-            os.path.join(os.path.dirname(__file__), '..', rel_path))
+        return os.path.abspath(os.path.join(os.path.dirname(__file__), "..", rel_path))
 
     @staticmethod
     def all_test_catalogs():
@@ -73,66 +89,71 @@ class TestCases:
             TestCases.test_case_4(),
             TestCases.test_case_5(),
             TestCases.test_case_7(),
-            TestCases.test_case_8()
+            TestCases.test_case_8(),
         ]
 
     @staticmethod
     def planet_disaster():
         return pystac.read_file(
-            test_data.get_path('data-files/planet-disaster/collection.json'))
+            test_data.get_path("data-files/planet-disaster/collection.json")
+        )
 
     @staticmethod
     def test_case_1():
         return Catalog.from_file(
-            test_data.get_path('data-files/catalogs/test-case-1/catalog.json'))
+            test_data.get_path("data-files/catalogs/test-case-1/catalog.json")
+        )
 
     @staticmethod
     def test_case_2():
         return Catalog.from_file(
-            test_data.get_path('data-files/catalogs/test-case-2/catalog.json'))
+            test_data.get_path("data-files/catalogs/test-case-2/catalog.json")
+        )
 
     @staticmethod
     def test_case_3():
-        root_cat = Catalog(id='test3',
-                           description='test case 3 catalog',
-                           title='test case 3 title')
+        root_cat = Catalog(
+            id="test3", description="test case 3 catalog", title="test case 3 title"
+        )
 
-        image_item = Item(id='imagery-item',
-                          geometry=RANDOM_GEOM,
-                          bbox=RANDOM_BBOX,
-                          datetime=datetime.utcnow(),
-                          properties={})
+        image_item = Item(
+            id="imagery-item",
+            geometry=RANDOM_GEOM,
+            bbox=RANDOM_BBOX,
+            datetime=datetime.utcnow(),
+            properties={},
+        )
 
         image_item.add_asset(
-            'ortho',
-            Asset(href='some/geotiff.tiff', media_type=MediaType.GEOTIFF))
+            "ortho", Asset(href="some/geotiff.tiff", media_type=MediaType.GEOTIFF)
+        )
 
         overviews = [
-            LabelOverview.create('label',
-                                 counts=[
-                                     LabelCount.create('one', 1),
-                                     LabelCount.create('two', 2)
-                                 ])
+            LabelOverview.create(
+                "label",
+                counts=[LabelCount.create("one", 1), LabelCount.create("two", 2)],
+            )
         ]
 
-        label_item = Item(id='label-items',
-                          geometry=RANDOM_GEOM,
-                          bbox=RANDOM_BBOX,
-                          datetime=datetime.utcnow(),
-                          properties={})
+        label_item = Item(
+            id="label-items",
+            geometry=RANDOM_GEOM,
+            bbox=RANDOM_BBOX,
+            datetime=datetime.utcnow(),
+            properties={},
+        )
 
         label_extension = LabelExtension.ext(label_item, add_if_missing=True)
-        label_extension.apply(label_description='ML Labels',
-                              label_type=LabelType.VECTOR,
-                              label_properties=['label'],
-                              label_classes=[
-                                  LabelClasses.create(classes=['one', 'two'],
-                                                      name='label')
-                              ],
-                              label_tasks=['classification'],
-                              label_methods=['manual'],
-                              label_overviews=overviews)
-        label_extension.add_source(image_item, assets=['ortho'])
+        label_extension.apply(
+            label_description="ML Labels",
+            label_type=LabelType.VECTOR,
+            label_properties=["label"],
+            label_classes=[LabelClasses.create(classes=["one", "two"], name="label")],
+            label_tasks=["classification"],
+            label_methods=["manual"],
+            label_overviews=overviews,
+        )
+        label_extension.add_source(image_item, assets=["ortho"])
 
         root_cat.add_item(image_item)
         root_cat.add_item(label_item)
@@ -146,31 +167,35 @@ class TestCases:
         See: https://www.drivendata.org/competitions/60/building-segmentation-disaster-resilience
         """
         return Catalog.from_file(
-            test_data.get_path('data-files/catalogs/test-case-4/catalog.json'))
+            test_data.get_path("data-files/catalogs/test-case-4/catalog.json")
+        )
 
     @staticmethod
     def test_case_5():
         """Based on a subset of https://cbers.stac.cloud/"""
         return Catalog.from_file(
-            test_data.get_path('data-files/catalogs/test-case-5/catalog.json'))
+            test_data.get_path("data-files/catalogs/test-case-5/catalog.json")
+        )
 
     @staticmethod
     def test_case_6():
         """Based on a subset of CBERS, contains a root and 4 empty children"""
         return Catalog.from_file(
-            test_data.get_path(
-                'data-files/catalogs/cbers-partial/catalog.json'))
+            test_data.get_path("data-files/catalogs/cbers-partial/catalog.json")
+        )
 
     @staticmethod
     def test_case_7():
         """Test case 4 as STAC version 0.8.1"""
         return Catalog.from_file(
-            test_data.get_path(
-                'data-files/catalogs/label_catalog_0_8_1/catalog.json'))
+            test_data.get_path("data-files/catalogs/label_catalog_0_8_1/catalog.json")
+        )
 
     @staticmethod
     def test_case_8():
         """Planet disaster data example catalog, 1.0.0-beta.2"""
         return pystac.read_file(
-            test_data.get_path('data-files/catalogs/'
-                               'planet-example-1.0.0-beta.2/collection.json'))
+            test_data.get_path(
+                "data-files/catalogs/" "planet-example-1.0.0-beta.2/collection.json"
+            )
+        )

--- a/tests/cli/commands/test_copy.py
+++ b/tests/cli/commands/test_copy.py
@@ -11,7 +11,6 @@ from .test_cases import TestCases
 
 
 class CopyTest(CliTestCase):
-
     def create_subcommand_functions(self):
         return [create_copy_command, create_move_assets_command]
 
@@ -19,10 +18,9 @@ class CopyTest(CliTestCase):
         cat = TestCases.planet_disaster()
         item_ids = set([i.id for i in cat.get_all_items()])
         with TemporaryDirectory() as tmp_dir:
-            self.run_command(['copy', cat.get_self_href(), tmp_dir])
+            self.run_command(["copy", cat.get_self_href(), tmp_dir])
 
-            copy_cat = pystac.read_file(
-                os.path.join(tmp_dir, 'collection.json'))
+            copy_cat = pystac.read_file(os.path.join(tmp_dir, "collection.json"))
             copy_cat_ids = set([i.id for i in copy_cat.get_all_items()])
 
             self.assertEqual(copy_cat_ids, item_ids)
@@ -35,23 +33,29 @@ class CopyTest(CliTestCase):
             cat.normalize_hrefs(tmp_dir)
             cat.save(catalog_type=pystac.CatalogType.ABSOLUTE_PUBLISHED)
 
-            cat2_dir = os.path.join(tmp_dir, 'second')
+            cat2_dir = os.path.join(tmp_dir, "second")
 
             command = [
-                'copy', '-t', 'SELF_CONTAINED', '-a',
-                cat.get_self_href(), cat2_dir
+                "copy",
+                "-t",
+                "SELF_CONTAINED",
+                "-a",
+                cat.get_self_href(),
+                cat2_dir,
             ]
             self.run_command(command)
-            cat2 = pystac.read_file(os.path.join(cat2_dir, 'collection.json'))
+            cat2 = pystac.read_file(os.path.join(cat2_dir, "collection.json"))
             for item in cat2.get_all_items():
                 item_href = item.get_self_href()
                 for asset in item.assets.values():
                     href = asset.href
                     self.assertFalse(is_absolute_href(href))
-                    common_path = os.path.commonpath([
-                        os.path.dirname(item_href),
-                        make_absolute_href(href, item_href)
-                    ])
+                    common_path = os.path.commonpath(
+                        [
+                            os.path.dirname(item_href),
+                            make_absolute_href(href, item_href),
+                        ]
+                    )
                     self.assertTrue(common_path, os.path.dirname(item_href))
 
     def test_copy_using_publish_location(self):
@@ -62,14 +66,20 @@ class CopyTest(CliTestCase):
             cat.normalize_hrefs(tmp_dir)
             cat.save(catalog_type=pystac.CatalogType.ABSOLUTE_PUBLISHED)
 
-            cat2_dir = os.path.join(tmp_dir, 'second')
+            cat2_dir = os.path.join(tmp_dir, "second")
 
             command = [
-                'copy', '-t', 'ABSOLUTE_PUBLISHED', '-a',
-                cat.get_self_href(), cat2_dir, '-l', href
+                "copy",
+                "-t",
+                "ABSOLUTE_PUBLISHED",
+                "-a",
+                cat.get_self_href(),
+                cat2_dir,
+                "-l",
+                href,
             ]
             self.run_command(command)
-            cat2 = pystac.read_file(os.path.join(cat2_dir, 'collection.json'))
+            cat2 = pystac.read_file(os.path.join(cat2_dir, "collection.json"))
             for link in cat2.get_child_links():
                 self.assertTrue(cast(str, link.target).startswith(href))
 
@@ -81,7 +91,7 @@ class CopyTest(CliTestCase):
             cat.save(catalog_type=pystac.CatalogType.RELATIVE_PUBLISHED)
             cat_href = cat.get_self_href()
 
-            command = ['move-assets', '-c', cat_href]
+            command = ["move-assets", "-c", cat_href]
             self.assertEqual(self.run_command(command).exit_code, 0)
             cat2 = pystac.read_file(cat_href)
             for item in cat2.get_all_items():
@@ -90,9 +100,11 @@ class CopyTest(CliTestCase):
                     href = asset.href
 
                     self.assertFalse(is_absolute_href(href))
-                    common_path = os.path.commonpath([
-                        os.path.dirname(item_href),
-                        make_absolute_href(href, item_href)
-                    ])
+                    common_path = os.path.commonpath(
+                        [
+                            os.path.dirname(item_href),
+                            make_absolute_href(href, item_href),
+                        ]
+                    )
 
                     self.assertEqual(common_path, os.path.dirname(item_href))

--- a/tests/cli/commands/test_lint.py
+++ b/tests/cli/commands/test_lint.py
@@ -10,13 +10,11 @@ from tests import test_data
 
 
 class LintTest(CliTestCase):
-
     def create_subcommand_functions(self) -> List[Callable[[Group], Command]]:
         return [create_lint_command]
 
     def test_valid_item(self) -> None:
-        path = test_data.get_path(
-            "data-files/linting/20201211_223832_cs2.json")
+        path = test_data.get_path("data-files/linting/20201211_223832_cs2.json")
         result = self.run_command(["lint", path])
         self.assertEqual(0, result.exit_code)
 

--- a/tests/cli/commands/test_merge.py
+++ b/tests/cli/commands/test_merge.py
@@ -17,7 +17,7 @@ def copy_two_planet_disaster_subsets(tmp_dir):
 
     Returns a list of collection paths in the temporary directory.
     """
-    item_ids = ['20170831_172754_101c', '20170831_162740_ssc1d1']
+    item_ids = ["20170831_172754_101c", "20170831_162740_ssc1d1"]
     new_cols = []
     for item_id in item_ids:
         col = TestCases.planet_disaster()
@@ -35,7 +35,6 @@ def copy_two_planet_disaster_subsets(tmp_dir):
 
 
 class MergeTest(CliTestCase):
-
     def create_subcommand_functions(self):
         return [create_merge_command]
 
@@ -43,7 +42,7 @@ class MergeTest(CliTestCase):
         with TemporaryDirectory() as tmp_dir:
             col_paths = copy_two_planet_disaster_subsets(tmp_dir)
 
-            cmd = ['merge', '-a', col_paths[0], col_paths[1]]
+            cmd = ["merge", "-a", col_paths[0], col_paths[1]]
 
             self.run_command(cmd)
 
@@ -56,13 +55,14 @@ class MergeTest(CliTestCase):
                 for asset in item.assets.values():
                     self.assertEqual(
                         os.path.dirname(asset.get_absolute_href()),
-                        os.path.dirname(item.get_self_href()))
+                        os.path.dirname(item.get_self_href()),
+                    )
 
     def test_merge_as_child(self):
         with TemporaryDirectory() as tmp_dir:
             col_paths = copy_two_planet_disaster_subsets(tmp_dir)
 
-            cmd = ['merge', '-a', "-c", col_paths[0], col_paths[1]]
+            cmd = ["merge", "-a", "-c", col_paths[0], col_paths[1]]
 
             self.run_command(cmd)
 
@@ -80,14 +80,15 @@ class MergeTest(CliTestCase):
             extent1 = pystac.read_file(col_paths[0]).extent
             extent2 = pystac.read_file(col_paths[1]).extent
 
-            xmin = min(
-                [extent1.spatial.bboxes[0][0], extent2.spatial.bboxes[0][0]])
-            time_max = max([
-                extent1.temporal.intervals[0][1],
-                extent2.temporal.intervals[0][1],
-            ])
+            xmin = min([extent1.spatial.bboxes[0][0], extent2.spatial.bboxes[0][0]])
+            time_max = max(
+                [
+                    extent1.temporal.intervals[0][1],
+                    extent2.temporal.intervals[0][1],
+                ]
+            )
 
-            cmd = ['merge', col_paths[0], col_paths[1]]
+            cmd = ["merge", col_paths[0], col_paths[1]]
 
             self.run_command(cmd)
 
@@ -106,59 +107,61 @@ class MergeTest(CliTestCase):
                 return result
 
             # Make sure it didn't just carry forward the old extent
-            self.assertNotEqual(set_of_values(result_extent.spatial.bboxes),
-                                set_of_values(extent2.spatial.bboxes))
+            self.assertNotEqual(
+                set_of_values(result_extent.spatial.bboxes),
+                set_of_values(extent2.spatial.bboxes),
+            )
 
             self.assertNotEqual(
                 set_of_values(result_extent.temporal.intervals),
-                set_of_values(extent2.temporal.intervals))
+                set_of_values(extent2.temporal.intervals),
+            )
 
             self.assertEqual(result_extent.spatial.bboxes[0][0], xmin)
             self.assertEqual(result_extent.temporal.intervals[0][1], time_max)
 
     def test_merges_assets(self):
-        item_id = '2017831_195552_SS02'
+        item_id = "2017831_195552_SS02"
 
         with TemporaryDirectory() as tmp_dir:
-            orig_data = os.path.dirname(
-                TestCases.planet_disaster().get_self_href())
-            shutil.copytree(orig_data, os.path.join(tmp_dir, '0'))
+            orig_data = os.path.dirname(TestCases.planet_disaster().get_self_href())
+            shutil.copytree(orig_data, os.path.join(tmp_dir, "0"))
 
-            col0 = pystac.read_file(os.path.join(tmp_dir, '0/collection.json'))
+            col0 = pystac.read_file(os.path.join(tmp_dir, "0/collection.json"))
             item = col0.get_item(item_id, recursive=True)
 
             new_col1 = col0.clone()
             new_col1.clear_children()
 
             item1 = item.clone()
-            del item1.assets['visual']
+            del item1.assets["visual"]
             new_col1.add_item(item1)
 
-            new_col1.normalize_hrefs(os.path.join(tmp_dir, 'a'))
+            new_col1.normalize_hrefs(os.path.join(tmp_dir, "a"))
             new_col1.save()
 
             new_col2 = col0.clone()
             new_col2.clear_children()
 
             item2 = item.clone()
-            del item2.assets['full-jpg']
+            del item2.assets["full-jpg"]
             new_col2.add_item(item2)
 
-            new_col2.normalize_hrefs(os.path.join(tmp_dir, 'b'))
+            new_col2.normalize_hrefs(os.path.join(tmp_dir, "b"))
             new_col2.save()
 
             cmd = [
-                'merge',
-                os.path.join(tmp_dir, 'a/collection.json'),
-                os.path.join(tmp_dir, 'b/collection.json'), '--move-assets',
-                '--ignore-conflicts'
+                "merge",
+                os.path.join(tmp_dir, "a/collection.json"),
+                os.path.join(tmp_dir, "b/collection.json"),
+                "--move-assets",
+                "--ignore-conflicts",
             ]
 
             self.run_command(cmd)
 
-            target_col = pystac.read_file(
-                os.path.join(tmp_dir, 'b/collection.json'))
+            target_col = pystac.read_file(os.path.join(tmp_dir, "b/collection.json"))
 
             result_item = target_col.get_item(item_id, recursive=True)
-            self.assertIn('visual', result_item.assets)
-            self.assertIn('full-jpg', result_item.assets)
+            self.assertIn("visual", result_item.assets)
+            self.assertIn("full-jpg", result_item.assets)

--- a/tests/cli/commands/test_validate.py
+++ b/tests/cli/commands/test_validate.py
@@ -7,21 +7,22 @@ from tests import test_data
 
 
 class ValidatateTest(CliTestCase):
-
     def create_subcommand_functions(self) -> List[Callable]:
         return [create_validate_command]
 
     def test_valid_item(self):
         path = test_data.get_path(
             "data-files/catalogs/test-case-1/country-1/area-1-1/"
-            "area-1-1-imagery/area-1-1-imagery.json")
+            "area-1-1-imagery/area-1-1-imagery.json"
+        )
         result = self.run_command(["validate", path, "--no-assets"])
         self.assertEqual(0, result.exit_code)
 
     def test_invalid_item(self):
         path = test_data.get_path(
             "data-files/catalogs/test-case-1/country-1/area-1-1/"
-            "area-1-1-imagery/area-1-1-imagery-invalid.json")
+            "area-1-1-imagery/area-1-1-imagery-invalid.json"
+        )
         result = self.run_command(["validate", path])
         self.assertEqual(1, result.exit_code)
 
@@ -42,6 +43,7 @@ class ValidatateTest(CliTestCase):
     def test_collection_invalid_asset(self):
         path = test_data.get_path(
             "data-files/catalogs/test-case-1/country-1"
-            "/area-1-1/area-1-1-imagery/area-1-1-imagery.json")
+            "/area-1-1/area-1-1-imagery/area-1-1-imagery.json"
+        )
         result = self.run_command(["validate", path])
         self.assertEqual(1, result.exit_code)

--- a/tests/cli/commands/test_version.py
+++ b/tests/cli/commands/test_version.py
@@ -9,16 +9,17 @@ from stactools.testing import CliTestCase
 
 
 class VersionTest(CliTestCase):
-
     def create_subcommand_functions(self):
         return [create_version_command]
 
     def test_hello_world(self):
-        result = self.run_command(['version'])
+        result = self.run_command(["version"])
         self.assertEqual(0, result.exit_code)
-        expected = (f"stactools version {__version__}\n"
-                    f"PySTAC version {pystac.__version__}\n"
-                    f"STAC version {get_stac_version()}\n")
+        expected = (
+            f"stactools version {__version__}\n"
+            f"PySTAC version {pystac.__version__}\n"
+            f"STAC version {get_stac_version()}\n"
+        )
         self.assertEqual(expected, result.output)
 
     def test_entry_point(self):

--- a/tests/core/test_create.py
+++ b/tests/core/test_create.py
@@ -9,29 +9,32 @@ from tests import test_data
 
 
 class CreateItem(TestCase):
-
     def setUp(self) -> None:
         self.path = test_data.get_path(
-            'data-files/planet-disaster/hurricane-harvey/'
-            'hurricane-harvey-0831/20170831_172754_101c/20170831_172754_101c_3b_Visual.tif'
+            "data-files/planet-disaster/hurricane-harvey/"
+            "hurricane-harvey-0831/20170831_172754_101c/20170831_172754_101c_3b_Visual.tif"
         )
 
     def test_one_datetime(self) -> None:
         item = create.item(self.path)
-        self.assertEqual(item.id,
-                         os.path.splitext(os.path.basename(self.path))[0])
+        self.assertEqual(item.id, os.path.splitext(os.path.basename(self.path))[0])
         self.assertIsNotNone(item.datetime)
         self.assertEqual(
-            item.geometry, {
-                'type':
-                'Polygon',
-                'coordinates':
-                [[[-95.780872, 29.517294], [-95.783782, 29.623358],
-                  [-96.041791, 29.617689], [-96.038613, 29.511649],
-                  [-95.780872, 29.517294]]]
-            })
-        self.assertEqual(item.bbox,
-                         [-96.041791, 29.511649, -95.780872, 29.623358])
+            item.geometry,
+            {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [-95.780872, 29.517294],
+                        [-95.783782, 29.623358],
+                        [-96.041791, 29.617689],
+                        [-96.038613, 29.511649],
+                        [-95.780872, 29.517294],
+                    ]
+                ],
+            },
+        )
+        self.assertEqual(item.bbox, [-96.041791, 29.511649, -95.780872, 29.623358])
         self.assertIsNone(item.common_metadata.start_datetime)
         self.assertIsNone(item.common_metadata.end_datetime)
 
@@ -41,14 +44,15 @@ class CreateItem(TestCase):
         self.assertIsNone(projection.projjson)
         self.assertEqual(
             projection.transform,
-            [97.69921875, 0.0, 205437.0, 0.0, -45.9609375, 3280290.0])
+            [97.69921875, 0.0, 205437.0, 0.0, -45.9609375, 3280290.0],
+        )
         self.assertEqual(projection.shape, (256, 256))
 
-        data = item.assets['data']
+        data = item.assets["data"]
         self.assertEqual(data.href, self.path)
         self.assertIsNone(data.title)
         self.assertIsNone(data.description)
-        self.assertEqual(data.roles, ['data'])
+        self.assertEqual(data.roles, ["data"])
         self.assertEqual(data.media_type, None)
         item.validate()
 

--- a/tests/core/test_io.py
+++ b/tests/core/test_io.py
@@ -7,21 +7,21 @@ from stactools.core import use_fsspec
 
 
 class IOTest(unittest.TestCase):
-
     def test_fsspec_io(self):
         use_fsspec()
 
         with TemporaryDirectory() as tmp_dir:
             catalog_url = (
-                'https://raw.githubusercontent.com/stac-utils/pystac/v0.5.2/tests/data-files/'
-                'catalogs/test-case-1/catalog.json')
+                "https://raw.githubusercontent.com/stac-utils/pystac/v0.5.2/tests/data-files/"
+                "catalogs/test-case-1/catalog.json"
+            )
 
             cat = pystac.read_file(catalog_url)
-            col = cat.get_child('country-1')
+            col = cat.get_child("country-1")
             self.assertEqual(len(list(col.get_children())), 2)
 
             cat.normalize_and_save(tmp_dir, pystac.CatalogType.SELF_CONTAINED)
 
-            cat2 = pystac.read_file(os.path.join(tmp_dir, 'catalog.json'))
-            col2 = cat2.get_child('country-1')
+            cat2 = pystac.read_file(os.path.join(tmp_dir, "catalog.json"))
+            col2 = cat2.get_child("country-1")
             self.assertEqual(len(list(col2.get_children())), 2)

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -16,7 +16,6 @@ from tests import test_data
 
 
 class CogifyTest(unittest.TestCase):
-
     @contextmanager
     def cogify(self, **kwargs):
         infile = test_data.get_path("data-files/core/byte.tif")
@@ -29,127 +28,132 @@ class CogifyTest(unittest.TestCase):
         with self.cogify() as outfile:
             self.assertTrue(os.path.exists(outfile))
             with rasterio.open(outfile) as dataset:
-                self.assertEqual(dataset.compression,
-                                 rasterio.enums.Compression.deflate)
+                self.assertEqual(
+                    dataset.compression, rasterio.enums.Compression.deflate
+                )
 
     def test_profile(self):
         with self.cogify(profile={"compress": "lzw"}) as outfile:
             self.assertTrue(os.path.exists(outfile))
             with rasterio.open(outfile) as dataset:
-                self.assertEqual(dataset.compression,
-                                 rasterio.enums.Compression.lzw)
+                self.assertEqual(dataset.compression, rasterio.enums.Compression.lzw)
 
 
 def test_antimeridian_split() -> None:
     # From https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.9
-    canonical = Polygon(
-        ((170, 40), (170, 50), (-170, 50), (-170, 40), (170, 40)))
+    canonical = Polygon(((170, 40), (170, 50), (-170, 50), (-170, 40), (170, 40)))
     split = antimeridian.split(canonical)
     assert split
-    expected = MultiPolygon((
-        shapely.geometry.box(170, 40, 180, 50),
-        shapely.geometry.box(-180, 40, -170, 50),
-    ))
+    expected = MultiPolygon(
+        (
+            shapely.geometry.box(170, 40, 180, 50),
+            shapely.geometry.box(-180, 40, -170, 50),
+        )
+    )
     for actual, expected in zip(split.geoms, expected.geoms):
         assert actual.equals(expected)
 
-    doesnt_cross = Polygon(
-        ((170, 40), (170, 50), (180, 50), (180, 40), (170, 40)))
+    doesnt_cross = Polygon(((170, 40), (170, 50), (180, 50), (180, 40), (170, 40)))
     split = antimeridian.split(doesnt_cross)
     assert split is None
 
     canonical_other_way = Polygon(
-        ((-170, 40), (170, 40), (170, 50), (-170, 50), (-170, 40)))
+        ((-170, 40), (170, 40), (170, 50), (-170, 50), (-170, 40))
+    )
     split = antimeridian.split(canonical_other_way)
     assert split
-    expected = MultiPolygon((
-        shapely.geometry.box(-180, 40, -170, 50),
-        shapely.geometry.box(170, 40, 180, 50),
-    ))
+    expected = MultiPolygon(
+        (
+            shapely.geometry.box(-180, 40, -170, 50),
+            shapely.geometry.box(170, 40, 180, 50),
+        )
+    )
     for actual, expected in zip(split.geoms, expected.geoms):
         assert actual.equals(expected), f"actual={actual}, expected={expected}"
 
 
 def test_antimeridian_split_complicated() -> None:
     complicated = Polygon(
-        ((170, 40), (170, 50), (-170, 50), (170, 45), (-170, 40), (170, 40)))
+        ((170, 40), (170, 50), (-170, 50), (170, 45), (-170, 40), (170, 40))
+    )
     split = antimeridian.split(complicated)
     assert split
-    expected = MultiPolygon((
-        Polygon(((170, 40), (170, 45), (180, 42.5), (180, 40), (170, 40))),
-        Polygon(((170, 45), (170, 50), (180, 50), (180, 47.5), (170, 45))),
-        Polygon(((-180, 50), (-170, 50), (-180, 47.5), (-180, 50))),
-        Polygon(((-180, 42.5), (-170, 40), (-180, 40), (-180, 42.5))),
-    ))
+    expected = MultiPolygon(
+        (
+            Polygon(((170, 40), (170, 45), (180, 42.5), (180, 40), (170, 40))),
+            Polygon(((170, 45), (170, 50), (180, 50), (180, 47.5), (170, 45))),
+            Polygon(((-180, 50), (-170, 50), (-180, 47.5), (-180, 50))),
+            Polygon(((-180, 42.5), (-170, 40), (-180, 40), (-180, 42.5))),
+        )
+    )
     for actual, expected in zip(split.geoms, expected.geoms):
         assert actual.equals(expected), f"actual={actual}, expected={expected}"
 
 
 def test_antimeridian_normalize() -> None:
-    canonical = Polygon(
-        ((170, 40), (170, 50), (-170, 50), (-170, 40), (170, 40)))
+    canonical = Polygon(((170, 40), (170, 50), (-170, 50), (-170, 40), (170, 40)))
     normalized = antimeridian.normalize(canonical)
     assert normalized
     expected = shapely.geometry.box(170, 40, 190, 50)
-    assert normalized.equals(
-        expected), f"actual={normalized}, expected={expected}"
+    assert normalized.equals(expected), f"actual={normalized}, expected={expected}"
 
     canonical_other_way = Polygon(
-        ((-170, 40), (170, 40), (170, 50), (-170, 50), (-170, 40)))
+        ((-170, 40), (170, 40), (170, 50), (-170, 50), (-170, 40))
+    )
     normalized = antimeridian.normalize(canonical_other_way)
     assert normalized
     expected = shapely.geometry.box(-170, 40, -190, 50)
-    assert normalized.equals(
-        expected), f"actual={normalized}, expected={expected}"
+    assert normalized.equals(expected), f"actual={normalized}, expected={expected}"
 
 
 def test_antimeridian_normalize_westerly() -> None:
-    westerly = Polygon(
-        ((170, 40), (170, 50), (-140, 50), (-140, 40), (170, 40)))
+    westerly = Polygon(((170, 40), (170, 50), (-140, 50), (-140, 40), (170, 40)))
     normalized = antimeridian.normalize(westerly)
     assert normalized
     expected = shapely.geometry.box(-190, 40, -140, 50)
-    assert normalized.equals(
-        expected), f"actual={normalized}, expected={expected}"
+    assert normalized.equals(expected), f"actual={normalized}, expected={expected}"
 
 
 def test_antimeridian_normalize_easterly() -> None:
-    easterly = Polygon(
-        ((-170, 40), (140, 40), (140, 50), (-170, 50), (-170, 40)))
+    easterly = Polygon(((-170, 40), (140, 40), (140, 50), (-170, 50), (-170, 40)))
     normalized = antimeridian.normalize(easterly)
     assert normalized
     expected = shapely.geometry.box(140, 40, 190, 50)
-    assert normalized.equals(
-        expected), f"actual={normalized}, expected={expected}"
+    assert normalized.equals(expected), f"actual={normalized}, expected={expected}"
 
 
 def test_item_fix_antimeridian_split() -> None:
-    canonical = Polygon(
-        ((170, 40), (170, 50), (-170, 50), (-170, 40), (170, 40)))
-    item = Item("an-id",
-                geometry=shapely.geometry.mapping(canonical),
-                bbox=canonical.bounds,
-                datetime=datetime.datetime.now(),
-                properties={})
+    canonical = Polygon(((170, 40), (170, 50), (-170, 50), (-170, 40), (170, 40)))
+    item = Item(
+        "an-id",
+        geometry=shapely.geometry.mapping(canonical),
+        bbox=canonical.bounds,
+        datetime=datetime.datetime.now(),
+        properties={},
+    )
     antimeridian.fix_item(item, antimeridian.Strategy.SPLIT)
-    expected = MultiPolygon((
-        shapely.geometry.box(170, 40, 180, 50),
-        shapely.geometry.box(-180, 40, -170, 50),
-    ))
+    expected = MultiPolygon(
+        (
+            shapely.geometry.box(170, 40, 180, 50),
+            shapely.geometry.box(-180, 40, -170, 50),
+        )
+    )
     for actual, expected in zip(
-            shapely.geometry.shape(item.geometry).geoms, expected.geoms):
+        shapely.geometry.shape(item.geometry).geoms, expected.geoms
+    ):
         assert actual.equals(expected)
     assert item.bbox == [170, 40, -170, 50]
 
 
 def test_item_fix_antimeridian_normalize() -> None:
-    canonical = Polygon(
-        ((170, 40), (170, 50), (-170, 50), (-170, 40), (170, 40)))
-    item = Item("an-id",
-                geometry=shapely.geometry.mapping(canonical),
-                bbox=canonical.bounds,
-                datetime=datetime.datetime.now(),
-                properties={})
+    canonical = Polygon(((170, 40), (170, 50), (-170, 50), (-170, 40), (170, 40)))
+    item = Item(
+        "an-id",
+        geometry=shapely.geometry.mapping(canonical),
+        bbox=canonical.bounds,
+        datetime=datetime.datetime.now(),
+        properties={},
+    )
     antimeridian.fix_item(item, antimeridian.Strategy.NORMALIZE)
     expected = shapely.geometry.box(170, 40, 190, 50)
     assert shapely.geometry.shape(item.geometry).equals(expected)
@@ -158,15 +162,19 @@ def test_item_fix_antimeridian_normalize() -> None:
 
 
 def test_item_fix_antimeridian_multipolygon_failure() -> None:
-    split = MultiPolygon((
-        shapely.geometry.box(170, 40, 180, 50),
-        shapely.geometry.box(-180, 40, -170, 50),
-    ))
-    item = Item("an-id",
-                geometry=shapely.geometry.mapping(split),
-                bbox=split.bounds,
-                datetime=datetime.datetime.now(),
-                properties={})
+    split = MultiPolygon(
+        (
+            shapely.geometry.box(170, 40, 180, 50),
+            shapely.geometry.box(-180, 40, -170, 50),
+        )
+    )
+    item = Item(
+        "an-id",
+        geometry=shapely.geometry.mapping(split),
+        bbox=split.bounds,
+        datetime=datetime.datetime.now(),
+        properties={},
+    )
     with pytest.raises(ValueError):
         antimeridian.fix_item(item, antimeridian.Strategy.SPLIT)
     with pytest.raises(ValueError):

--- a/tests/testing/__init__.py
+++ b/tests/testing/__init__.py
@@ -1,7 +1,8 @@
 from stactools.testing import TestData
 
 test_data = TestData(
-    __file__, {
+    __file__,
+    {
         "item.json": {
             "url": "https://raw.githubusercontent.com/radiantearth/"
             "stac-spec/v1.0.0/examples/simple-item.json",
@@ -11,19 +12,18 @@ test_data = TestData(
             "url": "s3://raster/AW3D30/AW3D30_global.vrt",
             "s3": {
                 "anon": True,
-                "client_kwargs": {
-                    "endpoint_url": "https://opentopography.s3.sdsc.edu"
-                }
-            }
+                "client_kwargs": {"endpoint_url": "https://opentopography.s3.sdsc.edu"},
+            },
         },
         "manifest.safe": {
-            "url":
-            ("https://sentinel2l2a01.blob.core.windows.net/"
-             "sentinel2-l2/03/K/TV/"
-             "2020/05/23/"
-             "S2A_MSIL2A_20200523T213041_N0212_R100_T03KTV_20200910T164427.SAFE/"
-             "manifest.safe"),
-            "planetary_computer":
-            True
-        }
-    })
+            "url": (
+                "https://sentinel2l2a01.blob.core.windows.net/"
+                "sentinel2-l2/03/K/TV/"
+                "2020/05/23/"
+                "S2A_MSIL2A_20200523T213041_N0212_R100_T03KTV_20200910T164427.SAFE/"
+                "manifest.safe"
+            ),
+            "planetary_computer": True,
+        },
+    },
+)

--- a/tests/testing/test_test_data.py
+++ b/tests/testing/test_test_data.py
@@ -19,8 +19,10 @@ class TestDataTest(TestCase):
         with open(path) as f:
             xml = f.read()
         self.assertNotEqual(
-            xml.find("ALPSMLC30_N041W106_DSM"), -1,
-            "Could not find 'ALPSMLC30_N041W106_DSM' in the ALOS VRT")
+            xml.find("ALPSMLC30_N041W106_DSM"),
+            -1,
+            "Could not find 'ALPSMLC30_N041W106_DSM' in the ALOS VRT",
+        )
 
     def test_external_pc_data(self):
         path = test_data.get_external_data("manifest.safe")


### PR DESCRIPTION
**Related Issue(s):**
- https://github.com/stac-utils/pystac/issues/316

**Description:**
We generally defer to PySTAC when it comes to tooling/formatting/linting decisions, and PySTAC uses black. The changes in `src/` and `test/` are _only_ from running `scripts/format`, there are no functional changes.

I'm queuing up another PR to introduce pre-commit and isort, but I'm doing this PR separately since there's so much formatting noise in the diff.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
