### PR TITLE
Fix antimeridian polygon winding order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Skip Click v8.1.0 as it broke decorator typing ([#266](https://github.com/stac-utils/stactools/pull/266))
 - Use black (instead of yapf) for formatting ([#274](https://github.com/stac-utils/stactools/pull/274))
 
+### Fixed
+
+- Antimeridian winding order ([#278](https://github.com/stac-utils/stactools/pull/278))
+
 ## [0.3.0] - 2022-03-25
 
 ### Added

--- a/src/stactools/core/utils/antimeridian.py
+++ b/src/stactools/core/utils/antimeridian.py
@@ -86,6 +86,7 @@ def split(polygon: Polygon) -> Optional[MultiPolygon]:
         return None
     geoms = list()
     for geom in split.geoms:
+        geom = shapely.geometry.polygon.orient(geom)
         bounds = geom.bounds
         if bounds[0] < -180:
             geoms.append(shapely.affinity.translate(geom, xoff=360))
@@ -129,7 +130,7 @@ def normalize(polygon: Polygon) -> Optional[Polygon]:
             coords[index + 1] = (end[0] - math.copysign(360, delta), end[1])
     if not has_changes:
         return None
-    polygon = Polygon(coords)
+    polygon = shapely.geometry.polygon.orient(Polygon(coords))
     centroid = polygon.centroid
     if centroid.x > 180:
         return shapely.affinity.translate(polygon, xoff=-360)

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -51,6 +51,7 @@ def test_antimeridian_split() -> None:
         )
     )
     for actual, expected in zip(split.geoms, expected.geoms):
+        assert actual.exterior.is_ccw
         assert actual.equals(expected)
 
     doesnt_cross = Polygon(((170, 40), (170, 50), (180, 50), (180, 40), (170, 40)))
@@ -69,6 +70,7 @@ def test_antimeridian_split() -> None:
         )
     )
     for actual, expected in zip(split.geoms, expected.geoms):
+        assert actual.exterior.is_ccw
         assert actual.equals(expected), f"actual={actual}, expected={expected}"
 
 
@@ -80,13 +82,30 @@ def test_antimeridian_split_complicated() -> None:
     assert split
     expected = MultiPolygon(
         (
-            Polygon(((170, 40), (170, 45), (180, 42.5), (180, 40), (170, 40))),
-            Polygon(((170, 45), (170, 50), (180, 50), (180, 47.5), (170, 45))),
-            Polygon(((-180, 50), (-170, 50), (-180, 47.5), (-180, 50))),
-            Polygon(((-180, 42.5), (-170, 40), (-180, 40), (-180, 42.5))),
+            Polygon(
+                [
+                    (180.0, 40.0),
+                    (180.0, 42.5),
+                    (170.0, 45.0),
+                    (170.0, 40.0),
+                    (180.0, 40.0),
+                ]
+            ),
+            Polygon([(-180.0, 42.5), (-180.0, 40.0), (-170.0, 40.0), (-180.0, 42.5)]),
+            Polygon(
+                [
+                    (180.0, 47.5),
+                    (180.0, 50.0),
+                    (170.0, 50.0),
+                    (170.0, 45.0),
+                    (180.0, 47.5),
+                ]
+            ),
+            Polygon([(-180.0, 50.0), (-180.0, 47.5), (-170.0, 50.0), (-180.0, 50.0)]),
         )
     )
     for actual, expected in zip(split.geoms, expected.geoms):
+        assert actual.exterior.is_ccw
         assert actual.equals(expected), f"actual={actual}, expected={expected}"
 
 
@@ -94,6 +113,7 @@ def test_antimeridian_normalize() -> None:
     canonical = Polygon(((170, 40), (170, 50), (-170, 50), (-170, 40), (170, 40)))
     normalized = antimeridian.normalize(canonical)
     assert normalized
+    assert normalized.exterior.is_ccw
     expected = shapely.geometry.box(170, 40, 190, 50)
     assert normalized.equals(expected), f"actual={normalized}, expected={expected}"
 
@@ -102,6 +122,7 @@ def test_antimeridian_normalize() -> None:
     )
     normalized = antimeridian.normalize(canonical_other_way)
     assert normalized
+    assert normalized.exterior.is_ccw
     expected = shapely.geometry.box(-170, 40, -190, 50)
     assert normalized.equals(expected), f"actual={normalized}, expected={expected}"
 
@@ -110,6 +131,8 @@ def test_antimeridian_normalize_westerly() -> None:
     westerly = Polygon(((170, 40), (170, 50), (-140, 50), (-140, 40), (170, 40)))
     normalized = antimeridian.normalize(westerly)
     assert normalized
+    assert normalized.exterior.is_ccw
+    expected = shapely.geometry.box(-170, 40, -190, 50)
     expected = shapely.geometry.box(-190, 40, -140, 50)
     assert normalized.equals(expected), f"actual={normalized}, expected={expected}"
 
@@ -118,6 +141,8 @@ def test_antimeridian_normalize_easterly() -> None:
     easterly = Polygon(((-170, 40), (140, 40), (140, 50), (-170, 50), (-170, 40)))
     normalized = antimeridian.normalize(easterly)
     assert normalized
+    assert normalized.exterior.is_ccw
+    expected = shapely.geometry.box(-170, 40, -190, 50)
     expected = shapely.geometry.box(140, 40, 190, 50)
     assert normalized.equals(expected), f"actual={normalized}, expected={expected}"
 


### PR DESCRIPTION
**Related Issue(s):** None

**Description:** The polygons produced by the antimeridian utils could (were always?) wound clockwise. They _should_ be wound counterclockwise. This fixes the problem, with unit tests.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
