### PR TITLE
Use stac-validator for validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use black (instead of yapf) for formatting ([#274](https://github.com/stac-utils/stactools/pull/274))
 - stac-check version and lint reporting ([#258](https://github.com/stac-utils/stactools/pull/258))
 - Sphinx theme ([#284](https://github.com/stac-utils/stactools/pull/284))
+- Use stac-validator for validation ([#289](https://github.com/stac-utils/stactools/pull/289))
 
 ### Fixed
 

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -9,3 +9,4 @@ pystac[validation] == 1.2
 rasterio == 1.2.9
 requests == 2.20
 stac-check == 1.2.0
+stac-validator == 3.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ install_requires =
     rasterio >= 1.2.9
     requests >= 2.20
     stac-check >= 1.2.0
+    stac-validator >= 3.1.0
 
 [options.extras_require]
 all =

--- a/src/stactools/cli/commands/validate.py
+++ b/src/stactools/cli/commands/validate.py
@@ -1,97 +1,66 @@
+import json
 import sys
-from typing import List, Optional
+from typing import Optional
 
 import click
-import pystac
-from pystac import Catalog, Collection, Item, STACObject, STACValidationError
-
-from stactools.core.utils import href_exists
+from stac_validator.validate import StacValidate
 
 
 def create_validate_command(cli: click.Group) -> click.Command:
     @cli.command("validate", short_help="Validate a stac object.")
     @click.argument("href")
     @click.option(
-        "--recurse/--no-recurse",
+        "--recursive/--no-recursive",
+        help="Recursively validate all STAC objects in this catalog.",
         default=True,
-        help=(
-            "If false, do not validate any children "
-            "(only useful for Catalogs and Collections"
-        ),
     )
     @click.option(
-        "--links/--no-links",
-        default=True,
-        help=("If false, do not check any of the objects's links."),
+        "--validate-links/--no-validate-links", help="Validate links.", default=True
     )
     @click.option(
-        "--assets/--no-assets",
-        default=True,
-        help=("If false, do not check any of the collection's/item's assets."),
+        "--validate-assets/--no-validate-assets", help="Validate assets.", default=True
     )
-    def validate_command(href: str, recurse: bool, links: bool, assets: bool) -> None:
+    @click.option("-v", "--verbose", is_flag=True, help="Enables verbose output.")
+    @click.option(
+        "--quiet/--no-quiet", help="Do not print output to console.", default=False
+    )
+    @click.option(
+        "--log-file",
+        help="Save output to file (local filepath).",
+    )
+    def validate_command(
+        href: str,
+        recursive: bool,
+        validate_links: bool,
+        validate_assets: bool,
+        verbose: bool,
+        quiet: bool,
+        log_file: Optional[str],
+    ) -> None:
         """Validates a STAC object.
 
-        Prints any validation errors to stdout.
+        This is a thin wrapper around
+        [stac-validate](https://github.com/stac-utils/stac-validator). Not all
+        command-line options are exposed. If you want more control over
+        validation, use `stac-validator` directly.
+
+        If you'd like linting, use `stac lint`.
         """
-        object = pystac.read_file(href)
-
-        if isinstance(object, Item):
-            errors = validate(object, None, False, links, assets)
+        validate = StacValidate(
+            href,
+            recursive=recursive,
+            links=validate_links,
+            assets=validate_assets,
+            verbose=verbose,
+            no_output=quiet,
+            log=log_file or "",
+        )
+        is_valid = validate.run()
+        if not quiet:
+            click.echo(json.dumps(validate.message, indent=4))
+        if is_valid:
+            sys.exit(0)
         else:
-            errors = validate(object, object, recurse, links, assets)
-
-        if not errors:
-            click.secho("OK", fg="green", nl=False)
-            click.echo(f" STAC object at {href} is valid!")
-        else:
-            for error in errors:
-                click.secho("ERROR", fg="red", nl=False)
-                click.echo(f" {error}")
             sys.exit(1)
 
     return validate_command
-
-
-def validate(
-    object: STACObject,
-    root: Optional[STACObject],
-    recurse: bool,
-    links: bool,
-    assets: bool,
-) -> List[str]:
-    errors: List[str] = []
-
-    try:
-        object.validate()
-    except FileNotFoundError as e:
-        errors.append(f"File not found: {e}")
-    except STACValidationError as e:
-        errors.append(f"{e}\n{e.source}")
-
-    if links:
-        for link in object.get_links():
-            href = link.get_absolute_href()
-            assert href
-            if not href_exists(href):
-                errors.append(
-                    f'Missing link in {object.self_href}: "{link.rel}" -> {link.href}'
-                )
-
-    if assets and (isinstance(object, Item) or isinstance(object, Collection)):
-        for name, asset in object.get_assets().items():
-            href = asset.get_absolute_href()
-            assert href
-            if not href_exists(href):
-                errors.append(
-                    f"Asset '{name}' does not exist: {asset.get_absolute_href()}"
-                )
-
-    if recurse:
-        assert isinstance(object, Catalog) or isinstance(object, Collection)
-        for child in object.get_children():
-            errors.extend(validate(child, root, recurse, links, assets))
-        for item in object.get_items():
-            errors.extend(validate(item, root, False, links, assets))
-
-    return errors

--- a/tests/cli/commands/test_validate.py
+++ b/tests/cli/commands/test_validate.py
@@ -1,6 +1,7 @@
 from typing import Callable, List
 
-from click import Group, Command
+from click import Command, Group
+
 from stactools.cli.commands.validate import create_validate_command
 from stactools.testing.cli_test import CliTestCase
 from tests import test_data
@@ -15,7 +16,7 @@ class ValidatateTest(CliTestCase):
             "data-files/catalogs/test-case-1/country-1/area-1-1/"
             "area-1-1-imagery/area-1-1-imagery.json"
         )
-        result = self.run_command(f"validate {path} --no-assets")
+        result = self.run_command(f"validate {path} --no-validate-assets")
         self.assertEqual(0, result.exit_code)
 
     def test_invalid_item(self) -> None:
@@ -37,7 +38,7 @@ class ValidatateTest(CliTestCase):
         path = test_data.get_path(
             "data-files/catalogs/test-case-1/country-1/area-1-1/collection-invalid.json"
         )
-        result = self.run_command(f"validate {path} --no-recurse")
+        result = self.run_command(f"validate {path} --no-recursive")
         self.assertEqual(0, result.exit_code)
 
     def test_collection_invalid_asset(self) -> None:
@@ -46,4 +47,6 @@ class ValidatateTest(CliTestCase):
             "/area-1-1/area-1-1-imagery/area-1-1-imagery.json"
         )
         result = self.run_command(f"validate {path}")
-        self.assertEqual(1, result.exit_code)
+        self.assertEqual(
+            0, result.exit_code
+        )  # unreachable links aren't an error in stac-validator

--- a/tests/cli/commands/test_validate.py
+++ b/tests/cli/commands/test_validate.py
@@ -1,48 +1,49 @@
 from typing import Callable, List
 
+from click import Group, Command
 from stactools.cli.commands.validate import create_validate_command
-from stactools.testing import CliTestCase
+from stactools.testing.cli_test import CliTestCase
 from tests import test_data
 
 
 class ValidatateTest(CliTestCase):
-    def create_subcommand_functions(self) -> List[Callable]:
+    def create_subcommand_functions(self) -> List[Callable[[Group], Command]]:
         return [create_validate_command]
 
-    def test_valid_item(self):
+    def test_valid_item(self) -> None:
         path = test_data.get_path(
             "data-files/catalogs/test-case-1/country-1/area-1-1/"
             "area-1-1-imagery/area-1-1-imagery.json"
         )
-        result = self.run_command(["validate", path, "--no-assets"])
+        result = self.run_command(f"validate {path} --no-assets")
         self.assertEqual(0, result.exit_code)
 
-    def test_invalid_item(self):
+    def test_invalid_item(self) -> None:
         path = test_data.get_path(
             "data-files/catalogs/test-case-1/country-1/area-1-1/"
             "area-1-1-imagery/area-1-1-imagery-invalid.json"
         )
-        result = self.run_command(["validate", path])
+        result = self.run_command(f"validate {path}")
         self.assertEqual(1, result.exit_code)
 
-    def test_collection_with_invalid_item(self):
+    def test_collection_with_invalid_item(self) -> None:
         path = test_data.get_path(
             "data-files/catalogs/test-case-1/country-1/area-1-1/collection-invalid.json"
         )
-        result = self.run_command(["validate", path])
+        result = self.run_command(f"validate {path}")
         self.assertEqual(1, result.exit_code)
 
-    def test_collection_with_invalid_item_no_validate_all(self):
+    def test_collection_with_invalid_item_no_validate_all(self) -> None:
         path = test_data.get_path(
             "data-files/catalogs/test-case-1/country-1/area-1-1/collection-invalid.json"
         )
-        result = self.run_command(["validate", path, "--no-recurse"])
+        result = self.run_command(f"validate {path} --no-recurse")
         self.assertEqual(0, result.exit_code)
 
-    def test_collection_invalid_asset(self):
+    def test_collection_invalid_asset(self) -> None:
         path = test_data.get_path(
             "data-files/catalogs/test-case-1/country-1"
             "/area-1-1/area-1-1-imagery/area-1-1-imagery.json"
         )
-        result = self.run_command(["validate", path])
+        result = self.run_command(f"validate {path}")
         self.assertEqual(1, result.exit_code)


### PR DESCRIPTION
**Related Issue(s):**
- Closes #255 
- Depends on https://github.com/stac-utils/stac-validator/pull/211

**Description:**
Switches from using custom validation code to https://github.com/stac-utils/stac-validator. Draft until stac-validator v3.1.0 is released.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
