### PR TITLE
Fix write_text_to_href

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,24 +15,26 @@ To release a new version of **stactools** or a [stactools-package](https://githu
 3. Determine the next version.
    If your version is `0.x.x` (MAJOR is 0), and you don't want to create a `1.x.x` release, shift the number semantics right, e.g. if your version is `0.2.5` and you make incompatible API changes, your next version is `0.3.0`.
     - If you're doing a pre-release, make sure to do it in a PyPI-compatible manner, as described in [PEP 440](https://www.python.org/dev/peps/pep-0440/#pre-releases).
-4. Create a new branch named `release/vX.X.X`, e.g. `release/v0.3.0`.
-5. If you're working in **stactools**, update [src/stactools/core/__init__.py](build/lib/stactools/cli/__init__.py) with your new version number.
+4. Search the library for the new version identifier to see if anything has been marked for deprecation.
+   If so, remove those items in a separate PR *before* opening the release PR.
+5. Create a new branch named `release/vX.X.X`, e.g. `release/v0.3.0`.
+6. If you're working in **stactools**, update [src/stactools/core/__init__.py](build/lib/stactools/cli/__init__.py) with your new version number.
    If you're in a package, update the appropriate `__init__.py` file.
-6. Update [CHANGELOG.md](CHANGELOG.md):
+7. Update [CHANGELOG.md](CHANGELOG.md):
    1. Change `[Unreleased]` to your new version number and add a date.
    2. Add a link to your new version at the bottom of the page, e.g. `[0.3.0]: <https://github.com/stac-utils/stactools/compare/v0.2.5..v0.3.0>`.
    3. Update the `[Unreleased]` link at the bottom of the page to start at your new release.
    4. Audit your new section of the CHANGELOG to ensure all relevant changes are captured.
-7. Open a pull request for your branch.
+8. Open a pull request for your branch.
    Include a "Release summary" section which includes the contents of your section of the CHANGELOG.
-8. Once approved, merge the branch.
-9.  Create an **annotated** tag at the new **main** HEAD named `vX.X.X`, e.g. `v0.3.0`.
+9.  Once approved, merge the branch.
+10. Create an **annotated** tag at the new **main** HEAD named `vX.X.X`, e.g. `v0.3.0`.
     - The contents of the tag should be the CHANGELOG contents for your version release.
       Be sure to remove any leading `###`, they'll be considered comments in the tag contents.
       See previous annotated tags for examples of formatting.
-10. Push your tag.
+11. Push your tag.
     This will fire off a special [release Github action](.github/workflows/release.yml) that will push your package to PyPI.
-11. Create a new release for your tag at https://github.com/stac-utils/stactools/releases.
+12. Create a new release for your tag at https://github.com/stac-utils/stactools/releases.
 
 
 ## FAQS

--- a/src/stactools/core/io/__init__.py
+++ b/src/stactools/core/io/__init__.py
@@ -3,6 +3,8 @@ from typing import Any, Callable, Optional
 import fsspec
 from pystac.stac_io import DefaultStacIO, StacIO
 
+from stactools.core import utils
+
 ReadHrefModifier = Callable[[str], str]
 """Type alias for a function parameter
 that allows users to manipulate HREFs for reading,
@@ -32,6 +34,15 @@ class FsspecStacIO(DefaultStacIO):
     def write_text_from_href(
         self, href: str, txt: str, *args: Any, **kwargs: Any
     ) -> None:
+        utils.deprecate(
+            "FsspecStacIO.write_text_from_href",
+            "FsspecStacIO.write_text_to_href",
+            "v0.5.0",
+        )
+        return self.write_text_to_href(href, txt)
+
+    def write_text_to_href(self, href: str, txt: str) -> None:
+        """Writes text to an href using fsspec."""
         with fsspec.open(href, "w") as destination:
             destination.write(txt)
 

--- a/src/stactools/core/utils/__init__.py
+++ b/src/stactools/core/utils/__init__.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Callable, Optional, TypeVar
 
 import fsspec
@@ -28,3 +29,12 @@ def gdal_driver_is_enabled(name: str) -> bool:
     """Checks to see if the named GDAL driver is enabled."""
     with rasterio.Env() as env:
         return name in env.drivers().keys()
+
+
+def deprecate(from_: str, to: str, version: str) -> None:
+    """Warn with DeprecationWarning and a pre-canned message."""
+    warnings.warn(
+        f"{from_} is deprecated and will be removed in {version}. Use {to} instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )


### PR DESCRIPTION
**Related Issue(s):**
- Closes #280 

**Description:**
The method was incorrectly named `write_text_from_href`. We have deprecated the old method, marking it for removal in v0.5.0.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [ ] Changes are added to the [CHANGELOG](../CHANGELOG.md).
