### PR TITLE
Release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.3.1]
+
 ### Added
 
 - CI check for Python 3.10 (requires pre-release version of rasterio 1.3) ([#271](https://github.com/stac-utils/stactools/pull/271))
@@ -257,7 +259,8 @@ See [#9](https://github.com/stac-utils/stactools/pull/9)
 - `stac.cli.command.layout` for modfiygin the layout of STACs
 - `stac.browse` for launching a local instance of stac-browser using docker.
 
-[Unreleased]: <https://github.com/stac-utils/stactools/compare/v0.3.0..main>
+[Unreleased]: <https://github.com/stac-utils/stactools/compare/v0.3.1..main>
+[0.3.1]: <https://github.com/stac-utils/stactools/compare/v0.3.0..v0.3.1>
 [0.3.0]: <https://github.com/stac-utils/stactools/compare/v0.2.6..v0.3.0>
 [0.2.6]: <https://github.com/stac-utils/stactools/compare/v0.2.5..v0.2.6>
 [0.2.5]: <https://github.com/stac-utils/stactools/compare/v0.2.4..v0.2.5>

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,11 +5,13 @@ To release a new version of **stactools** or a [stactools-package](https://githu
 1. Determine if it should be a major, minor, or tiny release.
    This project uses [semantic versioning](https://semver.org/).
    While we haven't always strictly adhered to semver in the past, we should do our best moving forward.
-   From the semver docs: 
+   From the semver docs:
    > given a version number MAJOR.MINOR.PATCH, increment the:
+   >
    > - MAJOR version when you make incompatible API changes,
    > - MINOR version when you add functionality in a backwards compatible manner, and
    > - PATCH version when you make backwards compatible bug fixes.
+   >
 2. Determine the current version.
    `git describe` helps, and if you are missing annotated tags use `git describe --tags`.
 3. Determine the next version.
@@ -18,7 +20,7 @@ To release a new version of **stactools** or a [stactools-package](https://githu
 4. Search the library for the new version identifier to see if anything has been marked for deprecation.
    If so, remove those items in a separate PR *before* opening the release PR.
 5. Create a new branch named `release/vX.X.X`, e.g. `release/v0.3.0`.
-6. If you're working in **stactools**, update [src/stactools/core/__init__.py](build/lib/stactools/cli/__init__.py) with your new version number.
+6. If you're working in **stactools**, update [`src/stactools/core/__init__.py`](src/stactools/core/__init__.py) with your new version number.
    If you're in a package, update the appropriate `__init__.py` file.
 7. Update [CHANGELOG.md](CHANGELOG.md):
    1. Change `[Unreleased]` to your new version number and add a date.
@@ -27,15 +29,14 @@ To release a new version of **stactools** or a [stactools-package](https://githu
    4. Audit your new section of the CHANGELOG to ensure all relevant changes are captured.
 8. Open a pull request for your branch.
    Include a "Release summary" section which includes the contents of your section of the CHANGELOG.
-9.  Once approved, merge the branch.
+9. Once approved, merge the branch.
 10. Create an **annotated** tag at the new **main** HEAD named `vX.X.X`, e.g. `v0.3.0`.
     - The contents of the tag should be the CHANGELOG contents for your version release.
       Be sure to remove any leading `###`, they'll be considered comments in the tag contents.
       See previous annotated tags for examples of formatting.
 11. Push your tag.
     This will fire off a special [release Github action](.github/workflows/release.yml) that will push your package to PyPI.
-12. Create a new release for your tag at https://github.com/stac-utils/stactools/releases.
-
+12. Create a new release for your tag in the [Github releases](https://github.com/stac-utils/stactools/releases).
 
 ## FAQS
 

--- a/src/stactools/core/__init__.py
+++ b/src/stactools/core/__init__.py
@@ -24,4 +24,4 @@ __all__ = [
     "move_all_assets",
     "use_fsspec",
 ]
-__version__ = "0.3.0"
+__version__ = "0.3.1"


### PR DESCRIPTION
**Related Issue(s):** None

**Description:** Release v0.3.1. Milestone: https://github.com/stac-utils/stactools/milestone/8?closed=1.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).

## Release notes

Will be included in the annotated tag:

```
v0.3.1

Added:

- CI check for Python 3.10 (requires pre-release version of rasterio 1.3) ([#271](https://github.com/stac-utils/stactools/pull/271))
- pre-commit and isort ([#275](https://github.com/stac-utils/stactools/pull/275))
- `stac info` now has option `-p` or `--progress` to update console output while reading the catalog ([#262](https://github.com/stac-utils/stactools/pull/262))
- More API documentation ([#282](https://github.com/stac-utils/stactools/pull/282))
- `FsspecStacIO.write_text_to_href` ([#291](https://github.com/stac-utils/stactools/pull/291))

Changed:

- Skip Click v8.1.0 as it broke decorator typing ([#266](https://github.com/stac-utils/stactools/pull/266))
- Use black (instead of yapf) for formatting ([#274](https://github.com/stac-utils/stactools/pull/274))
- stac-check version and lint reporting ([#258](https://github.com/stac-utils/stactools/pull/258))
- Sphinx theme ([#284](https://github.com/stac-utils/stactools/pull/284))
- Use stac-validator for validation ([#289](https://github.com/stac-utils/stactools/pull/289))

Fixed:

- Antimeridian winding order ([#278](https://github.com/stac-utils/stactools/pull/278))
- Test, lint, and format scripts ([#290](https://github.com/stac-utils/stactools/pull/290))

Deprecated:

- `FsspecStacIO.write_text_from_href` will be removed in v0.5.0 ([#291](https://github.com/stac-utils/stactools/pull/291))
```