### PR TITLE
Make numpy optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Make numpy an optional dependency ([#296](https://github.com/stac-utils/stactools/pull/296))
+
 ## [v0.3.1]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -41,14 +41,22 @@ If your system GDAL is older than version 3.1, consider using [Docker](#using-do
 
 ### Optional dependencies
 
-`stactools` includes one optional dependency:
+`stactools` includes two optional dependencies:
 
 - `s3`: Enables s3 hrefs via `fsspec` and `s3fs`
+- `numpy`: Add histrogram generation to `addraster`
 
-To install the single optional dependency:
+To install a single optional dependency:
 
 ```sh
-pip install stactools[s3]
+pip install 'stactools[s3]'
+pip install 'stactools[numpy]'
+```
+
+To install all optional dependencies:
+
+```sh
+pip install 'stactools[all]'
 ```
 
 ### Python 3.10

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -3,7 +3,6 @@ aiohttp == 3.8
 click == 8.1.3
 fsspec == 2021.7
 lxml == 4.6
-numpy == 1.21.0
 pyproj == 3.0
 pystac[validation] == 1.2
 rasterio == 1.2.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,6 @@ install_requires =
     click >= 8.1.3
     fsspec >= 2021.7
     lxml >= 4.6
-    numpy >= 1.21.0
     pyproj >= 3.0
     pystac[validation] >= 1.2
     rasterio >= 1.2.9
@@ -48,8 +47,11 @@ install_requires =
 [options.extras_require]
 all =
     %(s3)s
+    %(numpy)s
 s3 =
     s3fs >= 2021.7
+numpy =
+    numpy >= 1.21.0
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
**Related Issue(s):**
- Numpy was introduced in #204 

**Description:**
Numpy is a pretty heavy dependency that's only used for one optional part of `addraster`. This commit makes it optional.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
