### PR TITLE
feat: command to add an asset to an item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Conda package, via [conda-forge](https://anaconda.org/conda-forge/stactools) ([#324](https://github.com/stac-utils/stactools/pull/324))
 - Context manager to ignore rasterio's NotGeoreferencedWarning ([#331](https://github.com/stac-utils/stactools/pull/331))
 - Added `raster_footprint` module to assist in populating the geometry of an Item from data coverage of its data assets ([#307](https://github.com/stac-utils/stactools/pull/307))
+- `stac add-asset` command to add an asset to an item ([#300](https://github.com/stac-utils/stactools/pull/300))
 
 ### Changed
 

--- a/src/stactools/cli/__init__.py
+++ b/src/stactools/cli/__init__.py
@@ -10,6 +10,7 @@ def register_plugin(registry: "Registry") -> None:
 
     from stactools.cli.commands import (
         add,
+        add_asset,
         add_raster,
         copy,
         create,
@@ -24,6 +25,7 @@ def register_plugin(registry: "Registry") -> None:
     )
 
     registry.register_subcommand(add.create_add_command)
+    registry.register_subcommand(add_asset.create_add_asset_command)
     registry.register_subcommand(add_raster.create_add_raster_command)
     registry.register_subcommand(copy.create_copy_command)
     registry.register_subcommand(create.create_create_item_command)

--- a/src/stactools/cli/commands/add_asset.py
+++ b/src/stactools/cli/commands/add_asset.py
@@ -2,6 +2,7 @@ from typing import List, Optional
 
 import click
 import pystac
+import pystac.utils
 
 from stactools.core import add_asset_to_item
 
@@ -78,9 +79,9 @@ def create_add_asset_command(cli: click.Group) -> click.Command:
         ignore_conflicts: bool = False,
     ) -> None:
         _add_asset(
-            item_path,
+            pystac.utils.make_absolute_href(item_path),
             asset_key,
-            asset_path,
+            pystac.utils.make_absolute_href(asset_path),
             title,
             description,
             media_type,

--- a/src/stactools/cli/commands/add_asset.py
+++ b/src/stactools/cli/commands/add_asset.py
@@ -1,0 +1,92 @@
+from typing import List, Optional
+
+import click
+import pystac
+
+from stactools.core import add_asset_to_item
+
+
+def _add_asset(
+    item_path: str,
+    asset_key: str,
+    asset_path: str,
+    title: Optional[str] = None,
+    description: Optional[str] = None,
+    media_type: Optional[str] = None,
+    roles: Optional[List[str]] = None,
+    move_assets: bool = False,
+    ignore_conflicts: bool = False,
+) -> None:
+    item = pystac.read_file(item_path)
+    if not isinstance(item, pystac.Item):
+        raise click.BadArgumentUsage(f"{item_path} is not a STAC Item")
+    asset = pystac.Asset(asset_path, title, description, media_type, roles)
+    item = add_asset_to_item(
+        item,
+        asset_key,
+        asset,
+        move_assets=move_assets,
+        ignore_conflicts=ignore_conflicts,
+    )
+    item.save_object()
+
+
+def create_add_asset_command(cli: click.Group) -> click.Command:
+    @cli.command("add-asset", short_help="Add an asset to an item.")
+    @click.argument("item_path")
+    @click.argument("asset_key")
+    @click.argument("asset_path")
+    @click.option("--title", help="Optional title of the asset")
+    @click.option(
+        "--description",
+        help=(
+            "Optional description of the asset providing additional details, "
+            "such as how it was processed or created."
+        ),
+    )
+    @click.option("--media-type", help="Optional media type of the asset")
+    @click.option(
+        "-r",
+        "--role",
+        "roles",
+        help="Optional, semantic roles of the asset",
+        multiple=True,
+    )
+    @click.option(
+        "--move-assets",
+        is_flag=True,
+        help="Move asset to the target Item's location.",
+    )
+    @click.option(
+        "--ignore-conflicts",
+        is_flag=True,
+        help=(
+            "If there already exists an asset with the given key or at the "
+            "target path (when `--move-assets` flag is set), do not raise an "
+            "error, leave the original asset from the target item in place."
+        ),
+    )
+    def add_asset_command(
+        item_path: str,
+        asset_key: str,
+        asset_path: str,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+        media_type: Optional[str] = None,
+        roles: Optional[List[str]] = None,
+        move_assets: bool = False,
+        ignore_conflicts: bool = False,
+    ) -> None:
+        _add_asset(
+            item_path,
+            asset_key,
+            asset_path,
+            title,
+            description,
+            media_type,
+            roles,
+            move_assets=move_assets,
+            ignore_conflicts=ignore_conflicts,
+        )
+
+    return add_asset_command

--- a/src/stactools/core/__init__.py
+++ b/src/stactools/core/__init__.py
@@ -1,4 +1,5 @@
 from stactools.core.add import add_item
+from stactools.core.add_asset import add_asset_to_item
 from stactools.core.add_raster import add_raster_to_item
 from stactools.core.copy import (
     copy_catalog,
@@ -12,6 +13,7 @@ from stactools.core.merge import merge_all_items, merge_items
 
 __all__ = [
     "add_item",
+    "add_asset_to_item",
     "add_raster_to_item",
     "copy_catalog",
     "layout_catalog",

--- a/src/stactools/core/add_asset.py
+++ b/src/stactools/core/add_asset.py
@@ -1,0 +1,66 @@
+import logging
+
+from pystac import Asset, Item
+from pystac.utils import is_absolute_href, make_relative_href
+
+from stactools.core.copy import move_asset_file_to_item
+
+logger = logging.getLogger(__name__)
+
+
+def add_asset_to_item(
+    item: Item,
+    key: str,
+    asset: Asset,
+    move_assets: bool = False,
+    ignore_conflicts: bool = False,
+) -> Item:
+    """Adds an asset to an item.
+
+    Args:
+        item (Item): The PySTAC Item to which the asset will be added.
+        key (str): The unique key of the asset.
+        asset (Asset): The PySTAC Asset to add.
+        move_assets (bool): If True, move the asset file alongside the target item.
+        ignore_conflicts (bool): If True, asset with the same key will not be added,
+            and asset file that would overwrite an existing file will not be moved.
+            If False, either of these situations will throw an error.
+
+    Returns:
+        Item: Returns an updated Item with the added Asset.
+            This operation mutates the Item.
+    """
+    item_href = item.get_self_href()
+    asset_href = asset.get_absolute_href()
+    if key in item.assets:
+        if not ignore_conflicts:
+            raise Exception(
+                f"Target item {item} already has an asset with key {key}, "
+                "cannot add asset in from {asset_href}"
+            )
+    else:
+        if not asset_href:
+            raise ValueError(
+                f"Asset {asset} must have an href to be added. The href "
+                "value should be an absolute path or URL."
+            )
+        if not item_href and move_assets:
+            raise ValueError(
+                f"Target Item {item} must have an href to move an asset to the item"
+            )
+        if not item_href and not is_absolute_href(asset.href):
+            raise ValueError(
+                f"Target Item {item} must have an href to add "
+                "an asset with a relative href"
+            )
+        if move_assets:
+            new_asset_href = move_asset_file_to_item(
+                item, asset_href, ignore_conflicts=ignore_conflicts
+            )
+        else:
+            if not is_absolute_href(asset.href) and item_href is not None:
+                asset_href = make_relative_href(asset_href, item_href)
+            new_asset_href = asset_href
+        asset.href = new_asset_href
+        item.add_asset(key, asset)
+    return item

--- a/tests/cli/commands/test_add_asset.py
+++ b/tests/cli/commands/test_add_asset.py
@@ -1,0 +1,51 @@
+import os
+from tempfile import TemporaryDirectory
+
+import pystac
+
+from stactools.cli.commands.add_asset import create_add_asset_command
+from stactools.testing import CliTestCase
+from tests import test_data
+from tests.utils import create_temp_copy
+
+
+class AddAssetTest(CliTestCase):
+    def create_subcommand_functions(self):
+        return [create_add_asset_command]
+
+    def test_add_asset_to_item(self):
+        with TemporaryDirectory() as tmp_dir:
+            item_path = create_temp_copy(
+                test_data.get_path("data-files/core/simple-item.json"),
+                tmp_dir,
+                "item.json",
+            )
+            item = pystac.read_file(item_path)
+            assert "test-asset" not in item.assets
+
+            asset_path = test_data.get_path("data-files/core/byte.tif")
+            cmd = [
+                "add-asset",
+                item_path,
+                "test-asset",
+                asset_path,
+                "--title",
+                "test",
+                "--description",
+                "placeholder asset",
+                "--role",
+                "thumbnail",
+                "--role",
+                "overview",
+            ]
+            res = self.run_command(cmd)
+            self.assertEqual(res.exit_code, 0)
+
+            item = pystac.read_file(item_path)
+            asset = item.assets["test-asset"]
+            assert isinstance(asset, pystac.Asset), asset
+            assert asset.href is not None, asset.to_dict()
+            assert os.path.isfile(asset.href), asset.to_dict()
+            assert asset.title == "test", asset.to_dict()
+            assert asset.description == "placeholder asset", asset.to_dict()
+            self.assertListEqual(asset.roles, ["thumbnail", "overview"])

--- a/tests/cli/commands/test_add_asset.py
+++ b/tests/cli/commands/test_add_asset.py
@@ -3,6 +3,7 @@ from tempfile import TemporaryDirectory
 from typing import Callable, List
 
 import pystac
+import pystac.utils
 from click import Command, Group
 from pystac import Item
 
@@ -53,3 +54,24 @@ class AddAssetTest(CliTestCase):
             assert asset.description == "placeholder asset", asset.to_dict()
             assert asset.roles
             self.assertListEqual(asset.roles, ["thumbnail", "overview"])
+
+    def test_add_asset_to_item_with_relative_paths(self) -> None:
+        with TemporaryDirectory() as tmp_dir:
+            item_path = create_temp_copy(
+                test_data.get_path("data-files/core/simple-item.json"),
+                tmp_dir,
+                "item.json",
+            )
+            asset_path = test_data.get_path("data-files/core/byte.tif")
+            cmd = [
+                "add-asset",
+                pystac.utils.make_relative_href(
+                    item_path, os.getcwd(), start_is_dir=True
+                ),
+                "test-asset",
+                pystac.utils.make_relative_href(
+                    asset_path, os.getcwd(), start_is_dir=True
+                ),
+            ]
+            result = self.run_command(cmd)
+            self.assertEqual(result.exit_code, 0)

--- a/tests/cli/commands/test_add_asset.py
+++ b/tests/cli/commands/test_add_asset.py
@@ -1,26 +1,29 @@
 import os
 from tempfile import TemporaryDirectory
+from typing import Callable, List
 
 import pystac
+from click import Command, Group
+from pystac import Item
 
 from stactools.cli.commands.add_asset import create_add_asset_command
-from stactools.testing import CliTestCase
+from stactools.testing.cli_test import CliTestCase
 from tests import test_data
 from tests.utils import create_temp_copy
 
 
 class AddAssetTest(CliTestCase):
-    def create_subcommand_functions(self):
+    def create_subcommand_functions(self) -> List[Callable[[Group], Command]]:
         return [create_add_asset_command]
 
-    def test_add_asset_to_item(self):
+    def test_add_asset_to_item(self) -> None:
         with TemporaryDirectory() as tmp_dir:
             item_path = create_temp_copy(
                 test_data.get_path("data-files/core/simple-item.json"),
                 tmp_dir,
                 "item.json",
             )
-            item = pystac.read_file(item_path)
+            item = Item.from_file(item_path)
             assert "test-asset" not in item.assets
 
             asset_path = test_data.get_path("data-files/core/byte.tif")
@@ -41,11 +44,12 @@ class AddAssetTest(CliTestCase):
             res = self.run_command(cmd)
             self.assertEqual(res.exit_code, 0)
 
-            item = pystac.read_file(item_path)
+            item = Item.from_file(item_path)
             asset = item.assets["test-asset"]
             assert isinstance(asset, pystac.Asset), asset
             assert asset.href is not None, asset.to_dict()
             assert os.path.isfile(asset.href), asset.to_dict()
             assert asset.title == "test", asset.to_dict()
             assert asset.description == "placeholder asset", asset.to_dict()
+            assert asset.roles
             self.assertListEqual(asset.roles, ["thumbnail", "overview"])

--- a/tests/core/test_add_asset.py
+++ b/tests/core/test_add_asset.py
@@ -2,7 +2,7 @@ import os
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
-import pystac
+from pystac import Asset, Item
 
 from stactools.core import add_asset_to_item
 from tests import test_data
@@ -10,28 +10,28 @@ from tests.utils import create_temp_copy
 
 
 class AddAssetTest(TestCase):
-    def test_add_asset_to_item(self):
+    def test_add_asset_to_item(self) -> None:
         """Test adding an asset to an item without moving the asset"""
         item_path = test_data.get_path("data-files/core/simple-item.json")
-        item = pystac.read_file(item_path)
-        assert isinstance(item, pystac.Item)
+        item = Item.from_file(item_path)
         assert "test-asset" not in item.assets
 
         asset_path = test_data.get_path("data-files/core/byte.tif")
-        asset = pystac.Asset(
+        asset = Asset(
             asset_path, "test", "placeholder asset", roles=["thumbnail", "overview"]
         )
         item = add_asset_to_item(item, "test-asset", asset)
 
         asset = item.assets["test-asset"]
-        assert isinstance(asset, pystac.Asset), asset
+        assert isinstance(asset, Asset), asset
         assert asset.href is not None, asset.to_dict()
         assert os.path.isfile(asset.href), asset.to_dict()
         assert asset.title == "test", asset.to_dict()
         assert asset.description == "placeholder asset", asset.to_dict()
+        assert asset.roles
         self.assertListEqual(asset.roles, ["thumbnail", "overview"])
 
-    def test_add_asset_move(self):
+    def test_add_asset_move(self) -> None:
         """Test adding an asset to an item and moving it to the item"""
         with TemporaryDirectory() as tmp_dir:
             item_path = create_temp_copy(
@@ -39,12 +39,12 @@ class AddAssetTest(TestCase):
                 tmp_dir,
                 "item.json",
             )
-            item = pystac.read_file(item_path)
+            item = Item.from_file(item_path)
             with TemporaryDirectory() as tmp_dir2:
                 asset_path = create_temp_copy(
                     test_data.get_path("data-files/core/byte.tif"), tmp_dir2, "test.tif"
                 )
-                asset = pystac.Asset(
+                asset = Asset(
                     asset_path,
                     "test",
                     "placeholder asset",
@@ -55,38 +55,42 @@ class AddAssetTest(TestCase):
                 )
 
                 asset = item.assets["test-asset"]
-                assert isinstance(asset, pystac.Asset), asset
+                assert isinstance(asset, Asset), asset
                 assert asset.href is not None, asset.to_dict()
                 assert os.path.isfile(asset.href), asset.to_dict()
+                asset_absolute_href = asset.get_absolute_href()
+                assert asset_absolute_href
+                item_self_href = item.get_self_href()
+                assert item_self_href
                 self.assertEqual(
-                    os.path.dirname(asset.get_absolute_href()),
-                    os.path.dirname(item.get_self_href()),
+                    os.path.dirname(asset_absolute_href),
+                    os.path.dirname(item_self_href),
                 )
 
-    def test_add_and_move_with_missing_item_href(self):
+    def test_add_and_move_with_missing_item_href(self) -> None:
         """Test that adding an asset with `move_assets` set to True raises an
         error if the item doesn't have an href
         """
         item_path = test_data.get_path("data-files/core/simple-item.json")
-        item = pystac.read_file(item_path)
+        item = Item.from_file(item_path)
         item.set_self_href(None)
 
         asset_path = test_data.get_path("data-files/core/byte.tif")
-        asset = pystac.Asset(
+        asset = Asset(
             asset_path, "test", "placeholder asset", roles=["thumbnail", "overview"]
         )
         with self.assertRaises(ValueError):
             add_asset_to_item(item, "test-asset", asset, move_assets=True)
 
-    def test_add_with_missing_item_href_relative_asset_href(self):
+    def test_add_with_missing_item_href_relative_asset_href(self) -> None:
         """Test that adding an asset with a relative href raises an error if
         the item doesn't have an href
         """
         item_path = test_data.get_path("data-files/core/simple-item.json")
-        item = pystac.read_file(item_path)
+        item = Item.from_file(item_path)
         item.set_self_href(None)
 
-        asset = pystac.Asset(
+        asset = Asset(
             "data-files/core/byte.tif",
             "test",
             "placeholder asset",
@@ -95,41 +99,39 @@ class AddAssetTest(TestCase):
         with self.assertRaises(ValueError):
             add_asset_to_item(item, "test-asset", asset)
 
-    def test_add_with_missing_item_href_absolute_asset_href(self):
+    def test_add_with_missing_item_href_absolute_asset_href(self) -> None:
         """Test that adding an asset with an absolute href works even if the
         item doesn't have an href
         """
         item_path = test_data.get_path("data-files/core/simple-item.json")
-        item = pystac.read_file(item_path)
+        item = Item.from_file(item_path)
         item.set_self_href(None)
 
         asset_path = test_data.get_path("data-files/core/byte.tif")
-        asset = pystac.Asset(
+        asset = Asset(
             asset_path, "test", "placeholder asset", roles=["thumbnail", "overview"]
         )
         add_asset_to_item(item, "test-asset", asset)
         asset = item.assets["test-asset"]
-        assert isinstance(asset, pystac.Asset), asset
+        assert isinstance(asset, Asset), asset
 
-    def test_missing_asset_href(self):
+    def test_missing_asset_href(self) -> None:
         """Test that adding an asset with a missing href raises an error"""
         item_path = test_data.get_path("data-files/core/simple-item.json")
-        item = pystac.read_file(item_path)
+        item = Item.from_file(item_path)
 
-        asset = pystac.Asset(
-            "", "test", "placeholder asset", roles=["thumbnail", "overview"]
-        )
+        asset = Asset("", "test", "placeholder asset", roles=["thumbnail", "overview"])
         with self.assertRaises(ValueError):
             add_asset_to_item(item, "test-asset", asset)
 
-    def test_add_asset_ignore_conflict(self):
+    def test_add_asset_ignore_conflict(self) -> None:
         """Test that adding an asset with an existing key doesn't raise any
         errors if `ignore_conflict` is set to True"""
         item_path = test_data.get_path("data-files/core/simple-item.json")
-        item = pystac.read_file(item_path)
+        item = Item.from_file(item_path)
 
         asset_path = test_data.get_path("data-files/core/byte.tif")
-        asset = pystac.Asset(
+        asset = Asset(
             asset_path, "test", "placeholder asset", roles=["thumbnail", "overview"]
         )
 

--- a/tests/core/test_add_asset.py
+++ b/tests/core/test_add_asset.py
@@ -1,0 +1,139 @@
+import os
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+import pystac
+
+from stactools.core import add_asset_to_item
+from tests import test_data
+from tests.utils import create_temp_copy
+
+
+class AddAssetTest(TestCase):
+    def test_add_asset_to_item(self):
+        """Test adding an asset to an item without moving the asset"""
+        item_path = test_data.get_path("data-files/core/simple-item.json")
+        item = pystac.read_file(item_path)
+        assert isinstance(item, pystac.Item)
+        assert "test-asset" not in item.assets
+
+        asset_path = test_data.get_path("data-files/core/byte.tif")
+        asset = pystac.Asset(
+            asset_path, "test", "placeholder asset", roles=["thumbnail", "overview"]
+        )
+        item = add_asset_to_item(item, "test-asset", asset)
+
+        asset = item.assets["test-asset"]
+        assert isinstance(asset, pystac.Asset), asset
+        assert asset.href is not None, asset.to_dict()
+        assert os.path.isfile(asset.href), asset.to_dict()
+        assert asset.title == "test", asset.to_dict()
+        assert asset.description == "placeholder asset", asset.to_dict()
+        self.assertListEqual(asset.roles, ["thumbnail", "overview"])
+
+    def test_add_asset_move(self):
+        """Test adding an asset to an item and moving it to the item"""
+        with TemporaryDirectory() as tmp_dir:
+            item_path = create_temp_copy(
+                test_data.get_path("data-files/core/simple-item.json"),
+                tmp_dir,
+                "item.json",
+            )
+            item = pystac.read_file(item_path)
+            with TemporaryDirectory() as tmp_dir2:
+                asset_path = create_temp_copy(
+                    test_data.get_path("data-files/core/byte.tif"), tmp_dir2, "test.tif"
+                )
+                asset = pystac.Asset(
+                    asset_path,
+                    "test",
+                    "placeholder asset",
+                    roles=["thumbnail", "overview"],
+                )
+                item = add_asset_to_item(
+                    item, "test-asset", asset, move_assets=True, ignore_conflicts=True
+                )
+
+                asset = item.assets["test-asset"]
+                assert isinstance(asset, pystac.Asset), asset
+                assert asset.href is not None, asset.to_dict()
+                assert os.path.isfile(asset.href), asset.to_dict()
+                self.assertEqual(
+                    os.path.dirname(asset.get_absolute_href()),
+                    os.path.dirname(item.get_self_href()),
+                )
+
+    def test_add_and_move_with_missing_item_href(self):
+        """Test that adding an asset with `move_assets` set to True raises an
+        error if the item doesn't have an href
+        """
+        item_path = test_data.get_path("data-files/core/simple-item.json")
+        item = pystac.read_file(item_path)
+        item.set_self_href(None)
+
+        asset_path = test_data.get_path("data-files/core/byte.tif")
+        asset = pystac.Asset(
+            asset_path, "test", "placeholder asset", roles=["thumbnail", "overview"]
+        )
+        with self.assertRaises(ValueError):
+            add_asset_to_item(item, "test-asset", asset, move_assets=True)
+
+    def test_add_with_missing_item_href_relative_asset_href(self):
+        """Test that adding an asset with a relative href raises an error if
+        the item doesn't have an href
+        """
+        item_path = test_data.get_path("data-files/core/simple-item.json")
+        item = pystac.read_file(item_path)
+        item.set_self_href(None)
+
+        asset = pystac.Asset(
+            "data-files/core/byte.tif",
+            "test",
+            "placeholder asset",
+            roles=["thumbnail", "overview"],
+        )
+        with self.assertRaises(ValueError):
+            add_asset_to_item(item, "test-asset", asset)
+
+    def test_add_with_missing_item_href_absolute_asset_href(self):
+        """Test that adding an asset with an absolute href works even if the
+        item doesn't have an href
+        """
+        item_path = test_data.get_path("data-files/core/simple-item.json")
+        item = pystac.read_file(item_path)
+        item.set_self_href(None)
+
+        asset_path = test_data.get_path("data-files/core/byte.tif")
+        asset = pystac.Asset(
+            asset_path, "test", "placeholder asset", roles=["thumbnail", "overview"]
+        )
+        add_asset_to_item(item, "test-asset", asset)
+        asset = item.assets["test-asset"]
+        assert isinstance(asset, pystac.Asset), asset
+
+    def test_missing_asset_href(self):
+        """Test that adding an asset with a missing href raises an error"""
+        item_path = test_data.get_path("data-files/core/simple-item.json")
+        item = pystac.read_file(item_path)
+
+        asset = pystac.Asset(
+            "", "test", "placeholder asset", roles=["thumbnail", "overview"]
+        )
+        with self.assertRaises(ValueError):
+            add_asset_to_item(item, "test-asset", asset)
+
+    def test_add_asset_ignore_conflict(self):
+        """Test that adding an asset with an existing key doesn't raise any
+        errors if `ignore_conflict` is set to True"""
+        item_path = test_data.get_path("data-files/core/simple-item.json")
+        item = pystac.read_file(item_path)
+
+        asset_path = test_data.get_path("data-files/core/byte.tif")
+        asset = pystac.Asset(
+            asset_path, "test", "placeholder asset", roles=["thumbnail", "overview"]
+        )
+
+        with self.assertRaises(Exception):
+            add_asset_to_item(item, "thumbnail", asset)
+        item = add_asset_to_item(item, "thumbnail", asset, ignore_conflicts=True)
+        assert item.assets["thumbnail"].title == "Thumbnail"

--- a/tests/data-files/core/simple-item.json
+++ b/tests/data-files/core/simple-item.json
@@ -1,0 +1,72 @@
+{
+  "type": "Feature",
+  "stac_version": "1.0.0",
+  "id": "CS3-20160503_132131_05",
+  "properties": {
+    "datetime": "2016-05-03T13:22:30.040000Z",
+    "title": "A CS3 item",
+    "license": "PDDL-1.0",
+    "providers": [
+      {
+        "name": "CoolSat",
+        "roles": [
+          "producer",
+          "licensor"
+        ],
+        "url": "https://cool-sat.com/"
+      }
+    ]
+  },
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -122.308150179,
+          37.488035566
+        ],
+        [
+          -122.597502109,
+          37.538869539
+        ],
+        [
+          -122.576687533,
+          37.613537207
+        ],
+        [
+          -122.2880486,
+          37.562818007
+        ],
+        [
+          -122.308150179,
+          37.488035566
+        ]
+      ]
+    ]
+  },
+  "links": [
+    {
+      "rel": "collection",
+      "href": "https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/collection-spec/examples/sentinel2.json"
+    }
+  ],
+  "assets": {
+    "analytic": {
+      "href": "http://cool-sat.com/catalog/CS3-20160503_132130_04/analytic.tif",
+      "title": "4-Band Analytic",
+      "product": "http://cool-sat.com/catalog/products/analytic.json"
+    },
+    "thumbnail": {
+      "href": "http://cool-sat.com/catalog/CS3-20160503_132130_04/thumbnail.png",
+      "title": "Thumbnail"
+    }
+  },
+  "bbox": [
+    -122.59750209,
+    37.48803556,
+    -122.2880486,
+    37.613537207
+  ],
+  "stac_extensions": [],
+  "collection": "CS3"
+}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,21 @@
+import os
+import shutil
+from tempfile import TemporaryDirectory
+
+
+def create_temp_copy(
+    src_path: str, tmp_dir: TemporaryDirectory, target_name: str
+) -> str:
+    """Create a temporary copy of a file
+
+    Args:
+        src_path (str): path of the file to be copied.
+        tmp_dir (TemporaryDirectory): path of the temporary directory where the file will be copied.
+        target_name (str): name of the file in the target location.
+
+    Returns:
+        str: path of the temporary copy of the file.
+    """
+    temp_path = os.path.join(tmp_dir, target_name)
+    shutil.copyfile(src_path, temp_path)
+    return temp_path

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,11 +1,8 @@
 import os
 import shutil
-from tempfile import TemporaryDirectory
 
 
-def create_temp_copy(
-    src_path: str, tmp_dir: TemporaryDirectory, target_name: str
-) -> str:
+def create_temp_copy(src_path: str, tmp_dir: str, target_name: str) -> str:
     """Create a temporary copy of a file
 
     Args:


### PR DESCRIPTION
**Related Issue(s):**
https://github.com/stac-utils/stactools/issues/147

**Description:**
Adds a command called `addasset` to add an asset to an item. It takes an item's path, an asset's key, path and optionally roles, type etc as argument. The command doesn't handle `extra_fields` yet. 

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
