### PR TITLE
build: fix failing ci builds for python 3.10

### DIFF
--- a/.github/setup/action.yml
+++ b/.github/setup/action.yml
@@ -34,6 +34,9 @@ runs:
       with:
         auto-update-conda: true
         python-version: ${{ inputs.python-version }}
+    - name: Set strict channel priority
+      run: conda config --set channel_priority strict
+      shell: bash -l {0}
     - name: Update Conda's environemnt
       run: conda env update -f environment.yml -n test
       shell: bash -l {0}

--- a/.github/setup/action.yml
+++ b/.github/setup/action.yml
@@ -34,9 +34,6 @@ runs:
       with:
         auto-update-conda: true
         python-version: ${{ inputs.python-version }}
-    - name: Set strict channel priority
-      run: conda config --set channel_priority strict
-      shell: bash -l {0}
     - name: Update Conda's environemnt
       run: conda env update -f environment.yml -n test
       shell: bash -l {0}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Set strict channel priority for conda to reduce package incompatibility ([#301](https://github.com/stac-utils/stactools/pull/301))
+
 ## [v0.3.1]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Set strict channel priority for conda to reduce package incompatibility ([#301](https://github.com/stac-utils/stactools/pull/301))
+- Specify installation channel to use for all conda packages to avoid incompatibility ([#301](https://github.com/stac-utils/stactools/pull/301))
 
 ## [v0.3.1]
 

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - gdal>=3.3
-  - geos>=3.3
-  - rasterio>=1.2
+  - conda-forge::gdal>=3.3
+  - conda-forge::geos>=3.3
+  - conda-forge::rasterio>=1.2
+  - conda-forge::libstdcxx-ng  # gdal dependency. Make sure it's from the same channel as gdal


### PR DESCRIPTION
Set strict channel priority for conda.

**Description:**
The CI build for Python 3.10 is failing because of broken GDAL installation. Setting strict channel priority fixes the package compatibility problem (ref: https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html#strict-channel-priority)

Examples of failing builds:
- https://github.com/stac-utils/stactools/runs/6549941864?check_suite_focus=true#step:5:71
- https://github.com/stac-utils/stactools/runs/6778770957?check_suite_focus=true#step:5:78


**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [na] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
