### PR TITLE
Relaxed typing for cmd parameter in CliTestCase.run_command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Specify installation channel to use for all conda packages to avoid incompatibility ([#301](https://github.com/stac-utils/stactools/pull/301))
 
+### Changed
+
+Relaxed typing for cmd parameter for the CliTestCase.run_command in cli_test.py
+
 ## [v0.3.1]
 
 ### Added

--- a/src/stactools/testing/cli_test.py
+++ b/src/stactools/testing/cli_test.py
@@ -1,7 +1,7 @@
 import logging
 import unittest
 from abc import ABC, abstractmethod
-from typing import Callable, List
+from typing import Callable, List, Optional, Union, Sequence
 
 import click
 from click.testing import CliRunner, Result
@@ -28,7 +28,7 @@ class CliTestCase(unittest.TestCase, ABC):
             create_subcommand(cli)
         self.cli = cli
 
-    def run_command(self, cmd: str) -> Result:
+    def run_command(self, cmd: Optional[Union[str, Sequence[str]]]) -> Result:
         runner = CliRunner()
         result = runner.invoke(self.cli, cmd, catch_exceptions=False)
         if result.output:


### PR DESCRIPTION
Before you submit a pull request, please fill in the following:

**Related Issue(s):**
https://github.com/stac-utils/stactools/issues/306

**Description:**
I modified the run_command function within the CliTestCase class so that the `cmd` parameter accepts either a string or a sequence of string values. 

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
