### PR TITLE
Removed Python 3.7

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
     defaults:
       run:
         shell: bash -l {0}
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
     defaults:
       run:
         shell: bash -l {0}
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9"]
     defaults:
       run:
         shell: bash -l {0}
@@ -80,7 +80,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
     defaults:
       run:
         shell: bash -l {0}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Modified stactools.core.utils.antimeridian.fix_item to return the item and updated 2 unit tests ([#309](https://github.com/stac-utils/stactools/issues/309))
 - Relaxed typing for cmd parameter for the CliTestCase.run_command in cli_test.py ([#306](https://github.com/stac-utils/stactools/issues/306))
 
+### Removed
+
+- Dropped support for Python 3.7 ([#223](https://github.com/stac-utils/stactools/issues/223))
+
 ## [v0.3.1]
 
 ### Added

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,7 +19,7 @@ See the `stactools-packages website <https://stactools-packages.github.io>`_ and
 Requirements
 ============
 
-* `Python 3.7 or greater <https://www.python.org/>`_
+* `Python 3.8 or greater <https://www.python.org/>`_
 
 STAC version support
 ====================

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -3,7 +3,7 @@ aiohttp == 3.8
 click == 8.1.3
 fsspec == 2021.7
 lxml == 4.6
-numpy == 1.21.0
+numpy == 1.22.0
 pyproj == 3.0
 pystac[validation] == 1.2
 rasterio == 1.2.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,9 +20,9 @@ keywords =
 classifiers =
     Development Status :: 4 - Beta
     License :: OSI Approved :: Apache Software License
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 
 [options]
 package_dir =
@@ -30,14 +30,14 @@ package_dir =
 packages = find_namespace:
 zip_safe = False
 include_package_data = True
-python_requires = >= 3.7
+python_requires = >= 3.8
 install_requires =
     Shapely >= 1.6
     aiohttp >= 3.8
     click >= 8.1.3
     fsspec >= 2021.7
     lxml >= 4.6
-    numpy >= 1.21.0
+    numpy >= 1.22.0
     pyproj >= 3.0
     pystac[validation] >= 1.2
     rasterio >= 1.2.9

--- a/src/stactools/core/addraster.py
+++ b/src/stactools/core/addraster.py
@@ -49,11 +49,6 @@ def _read_bands(href: str) -> List[RasterBand]:
             band.nodata = dataset.nodatavals[i]
             band.spatial_resolution = dataset.transform[0]
             band.data_type = DataType(dataset.dtypes[i])
-            # These `type: ignore` comments are required until `numpy>=1.22.0`.
-            # When the minimum numpy version reaches v1.22.0 (which requires us
-            # to drop Python 3.7), then we can remove these `type: ignore`
-            # comments and remove the `warn_unused_ignores = True` line from
-            # `mypy.ini`.
             minimum = float(numpy.min(data))
             maximum = float(numpy.max(data))
             band.statistics = Statistics.create(minimum=minimum, maximum=maximum)

--- a/src/stactools/core/addraster.py
+++ b/src/stactools/core/addraster.py
@@ -53,12 +53,10 @@ def _read_bands(href: str) -> List[RasterBand]:
             # to drop Python 3.7), then we can remove these `type: ignore`
             # comments and remove the `warn_unused_ignores = True` line from
             # `mypy.ini`.
-            minimum = float(numpy.min(data))  # type: ignore
-            maximum = float(numpy.max(data))  # type: ignore
+            minimum = float(numpy.min(data))
+            maximum = float(numpy.max(data))
             band.statistics = Statistics.create(minimum=minimum, maximum=maximum)
-            hist_data, _ = numpy.histogram(  # type: ignore
-                data, range=(minimum, maximum), bins=BINS
-            )
+            hist_data, _ = numpy.histogram(data, range=(minimum, maximum), bins=BINS)
             band.histogram = Histogram.create(
                 BINS, minimum, maximum, hist_data.tolist()
             )


### PR DESCRIPTION
Before you submit a pull request, please fill in the following:

**Related Issue(s):**
- https://github.com/stac-utils/stactools/issues/223

**Description:**
Removed support for Python 3.7, changed minimum numpy version to v1.22

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
