### PR TITLE
Antimeridian fixes now allow multipolygons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added geometry.py for handling common geometrical operations like bounding boxes from GeoJSON ([#314](https://github.com/stac-utils/stactools/pull/314))
 - Specify installation channel to use for all conda packages to avoid incompatibility ([#301](https://github.com/stac-utils/stactools/pull/301))
+- Allow MultiPolygons when fixing antimeridian issues ([#317](https://github.com/stac-utils/stactools/pull/317))
 
 ### Changed
 

--- a/src/stactools/core/utils/antimeridian.py
+++ b/src/stactools/core/utils/antimeridian.py
@@ -24,7 +24,9 @@ class Strategy(Enum):
 
 def fix_item(item: Item, strategy: Strategy) -> Item:
     """Modifies an item in-place to deal with antimeridian issues.
-    If the item's geometry is not a `Polygon`, raises a `ValueError`.
+
+    If the item's geometry is not a :py:class:`Polygon`` or a
+    :py:class:`MultiPolygon`, raises a :py:class:`ValueError`.
 
     Args:
         item (pystac.Item): The item to be modified.
@@ -33,18 +35,28 @@ def fix_item(item: Item, strategy: Strategy) -> Item:
         Item: The input item, whether it was modified or not.
     """
     geometry = shapely.geometry.shape(item.geometry)
-    if not isinstance(geometry, Polygon):
+    if isinstance(geometry, Polygon):
+        multi_polygon = False
+    elif isinstance(geometry, MultiPolygon):
+        multi_polygon = True
+    else:
         raise ValueError(
-            f"Can only fix antimeridian issues for Polygons, geometry={geometry}"
+            f"Can only fix antimeridian issues for Polygons or MultiPolygons, geometry={geometry}"
         )
     if strategy == Strategy.NORMALIZE:
-        normalized_geometry = normalize(geometry)
+        if multi_polygon:
+            normalized_geometry = normalize_multipolygon(geometry)
+        else:
+            normalized_geometry = normalize(geometry)
         if normalized_geometry:
             bbox = normalized_geometry.bounds
             item.geometry = shapely.geometry.mapping(normalized_geometry)
             item.bbox = bbox
     elif strategy == Strategy.SPLIT:
-        split_geometry = split(geometry)
+        if multi_polygon:
+            split_geometry = split_multipolygon(geometry)
+        else:
+            split_geometry = split(geometry)
         if split_geometry:
             xmin = 180
             xmax = -180
@@ -105,6 +117,36 @@ def split(polygon: Polygon) -> Optional[MultiPolygon]:
     return MultiPolygon(geoms)
 
 
+def split_multipolygon(multi_polygon: MultiPolygon) -> Optional[MultiPolygon]:
+    """Splits multiple WGS84 polygons into a multipolygon across the antimeridian.
+
+    If none of the contained polygons cross the antimeridian, returns None. Only
+    handles exterior rings (can't handle interior).
+
+    Note:
+        Will not work on polygons that enclose the north or south poles.
+
+    Todo:
+        Fix this
+
+    Args:
+        multi_polygon (:py:class:`shapely.geometry.MultiPolygon`): The input multi polygon.
+
+    Returns:
+        Optional[:py:class:`shapely.geometry.MultiPolygon`]:
+            The output polygons, or None if no split occurred.
+    """
+    polygons = []
+    for polygon in multi_polygon.geoms:
+        split_polygon = split(polygon)
+        if split_polygon:
+            polygons.extend(split_polygon.geoms)
+    if polygons:
+        return MultiPolygon(polygons)
+    else:
+        return None
+
+
 def normalize(polygon: Polygon) -> Optional[Polygon]:
     """'Normalizes' a WGS84 lat/lon polygon, or returns None if no changes were made.
 
@@ -149,3 +191,39 @@ def normalize(polygon: Polygon) -> Optional[Polygon]:
         return shapely.affinity.translate(polygon, xoff=+360)
     else:
         return polygon
+
+
+def normalize_multipolygon(multi_polygon: MultiPolygon) -> Optional[MultiPolygon]:
+    """'Normalizes' a WGS84 lat/lon multi polygon, or returns None if no changes were made.
+
+    For each polygon in the multi-polygon, this converts the x coordinates to
+    all be the same sign, even if the polygon crosses the antimeridian. Although
+    the x coordinate sign within each polygon will be made the same, the sign
+    may differ between polygons depending on their position relative to the
+    antimeridian.
+
+    Note:
+        Will not work on polygons that enclose the north or south poles.
+
+    Todo:
+        Fix this
+
+    Args:
+        multi_polygon (:py:class:`shapely.geometry.MultiPolygon`): The input multi-polygon.
+
+    Returns:
+        Optional[:py:class:`shapely.geometry.MultiPolygon`]: The normalized multi-polygon.
+    """
+    polygons = list()
+    changes_made = False
+    for polygon in multi_polygon.geoms:
+        normalized_polygon = normalize(polygon)
+        if normalized_polygon:
+            polygons.append(normalized_polygon)
+            changes_made = True
+        else:
+            polygons.append(polygon)
+    if changes_made:
+        return MultiPolygon(polygons)
+    else:
+        return None


### PR DESCRIPTION
**Related Issue(s):**
- Closes #316 

**Description:**
Extend the antimeridian module to allow multipolygons. The `fix_item` function checks whether the geometry is a polygon or multi-polygon, and reacts accordingly. MultiPolygons are split/normalized via new functions to keep the existing functionality untouched, since they require slightly different logic to work.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
