### PR TITLE
Summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Include kwargs in io `read_text` for use with internal `fsspec.open` call. ([#372](https://github.com/stac-utils/stactools/pull/372))
 - Python 3.11 support ([#376](https://github.com/stac-utils/stactools/pull/376))
+- `stac summary` command ([#323](https://github.com/stac-utils/stactools/pull/323))
 
 ### Changed
 

--- a/src/stactools/cli/__init__.py
+++ b/src/stactools/cli/__init__.py
@@ -19,6 +19,7 @@ def register_plugin(registry: "Registry") -> None:
         lint,
         merge,
         migrate,
+        summary,
         update_geometry,
         validate,
         version,
@@ -35,6 +36,7 @@ def register_plugin(registry: "Registry") -> None:
     registry.register_subcommand(layout.create_layout_command)
     registry.register_subcommand(lint.create_lint_command)
     registry.register_subcommand(merge.create_merge_command)
+    registry.register_subcommand(summary.create_summary_command)
     registry.register_subcommand(validate.create_validate_command)
     registry.register_subcommand(version.create_version_command)
     registry.register_subcommand(update_geometry.create_update_geometry_command)

--- a/src/stactools/cli/commands/summary.py
+++ b/src/stactools/cli/commands/summary.py
@@ -1,0 +1,57 @@
+from typing import Any
+
+import click
+import pystac
+from pystac import Catalog, Collection
+
+
+def format_summary(summary: dict[str, Any], indent: int = 4) -> str:
+    out = ""
+    for var in summary:
+        if type(summary[var]) == dict:
+            out += var + ": \n" + " " * indent + str(summary[var]) + "\n"
+        else:
+            out += var + ": " + str(summary[var]) + "\n"
+    return out
+
+
+def print_summaries(collection_path: str, force_resummary: bool = False) -> None:
+    col = pystac.read_file(collection_path)
+    if isinstance(col, Collection):
+        orig_summaries = col.summaries.to_dict()
+        if force_resummary or len(orig_summaries) == 0:
+            new_summaries = pystac.summaries.Summarizer().summarize(col).to_dict()
+            if len(orig_summaries) == 0:
+                print(
+                    "Collection's summaries were empty. Printing recalculated summaries:"
+                )
+            print(format_summary(new_summaries))
+        else:
+            print(format_summary(orig_summaries))
+    elif isinstance(col, Catalog):
+        print("Input is a catalog, not a collection.")
+        print(
+            "Run 'stac describe -h {}' to discover collections in this catalog".format(
+                collection_path
+            )
+        )
+        return
+    else:
+        print("{} is not a collection".format(collection_path))
+        return
+
+
+def create_summary_command(cli: click.Group) -> click.Command:
+    @cli.command("summary", short_help="Summarize a STAC collection's contents.")
+    @click.option(
+        "-f",
+        "--force_resummary",
+        is_flag=True,
+        default=False,
+        help="Ignore existing summaries in the collection and print recalculated summaries",
+    )
+    @click.argument("collection_path")
+    def summary_command(collection_path: str, force_resummary: bool) -> None:
+        print_summaries(collection_path, force_resummary)
+
+    return summary_command

--- a/src/stactools/cli/commands/summary.py
+++ b/src/stactools/cli/commands/summary.py
@@ -1,11 +1,11 @@
-from typing import Any
+from typing import Any, Dict
 
 import click
 import pystac
 from pystac import Catalog, Collection
 
 
-def format_summary(summary: dict[str, Any], indent: int = 4) -> str:
+def format_summary(summary: Dict[str, Any], indent: int = 4) -> str:
     out = ""
     for var in summary:
         if type(summary[var]) == dict:

--- a/tests/cli/commands/test_summary.py
+++ b/tests/cli/commands/test_summary.py
@@ -1,0 +1,17 @@
+from typing import Callable, List
+
+from click import Command, Group
+
+from stactools.cli.commands.summary import create_summary_command
+from stactools.testing.cli_test import CliTestCase
+from tests import test_data
+
+
+class SummaryTest(CliTestCase):
+    def create_subcommand_functions(self) -> List[Callable[[Group], Command]]:
+        return [create_summary_command]
+
+    def test_summary(self) -> None:
+        path = test_data.get_path("data-files/planet-disaster/collection.json")
+        result = self.run_command(f"summary {path}")
+        self.assertEqual(0, result.exit_code)


### PR DESCRIPTION
**Related Issue(s):**
Implements #45 for collections

**Description:**
`stac summary` now prints summaries that already exist in the JSON, or can generate them for the default fields if they are missing or with the `-f, --force_resummary` flag. The `collection.json` is left unchanged; new summaries are only output to the console.  

Generating or displaying summaries for specified fields only has not been implemented.  

Because summaries are no longer supported for catalogs, it suggests running `stac describe -h CATALOG_HREF` if a catalog is given as input.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).

I'm having trouble with the tests, and I'm not sure why. They complete successfully when I checkout `main`.

```
______________________________________________________________ ERROR collecting tests/cli/commands/test_add_raster.py _______________________________________________________________
ImportError while importing test module '/Users/jrush/projects/stactools/tests/cli/commands/test_add_raster.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../opt/miniconda3/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/cli/commands/test_add_raster.py:6: in <module>
    from stactools.cli.commands.add_raster import create_add_raster_command
E   ModuleNotFoundError: No module named 'stactools.cli.commands.add_raster'
_________________________________________________________________ ERROR collecting tests/core/utils/test_convert.py _________________________________________________________________
ImportError while importing test module '/Users/jrush/projects/stactools/tests/core/utils/test_convert.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../opt/miniconda3/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/core/utils/test_convert.py:8: in <module>
    from stactools.core.utils.convert import cogify, cogify_subdatasets
E   ImportError: cannot import name 'cogify_subdatasets' from 'stactools.core.utils.convert' (/Users/jrush/projects/stactools/venv/lib/python3.9/site-packages/stactools/core/utils/convert.py)
```