### PR TITLE
Add utility to ignore NotGeoreferencedWarning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Specify installation channel to use for all conda packages to avoid incompatibility ([#301](https://github.com/stac-utils/stactools/pull/301))
 - Allow MultiPolygons when fixing antimeridian issues ([#317](https://github.com/stac-utils/stactools/pull/317))
 - Conda package, via [conda-forge](https://anaconda.org/conda-forge/stactools) ([#324](https://github.com/stac-utils/stactools/pull/324))
+- Context manager to ignore rasterio's NotGeoreferencedWarning ([#331](https://github.com/stac-utils/stactools/pull/331))
 
 ### Changed
 

--- a/src/stactools/core/utils/__init__.py
+++ b/src/stactools/core/utils/__init__.py
@@ -1,11 +1,13 @@
 """General utility functions."""
 
 import warnings
-from typing import Callable, Optional, TypeVar
+from contextlib import contextmanager
+from typing import Callable, Generator, Optional, TypeVar
 
 import fsspec
 import pystac.utils
 import rasterio
+from rasterio.errors import NotGeoreferencedWarning
 
 T = TypeVar("T")
 U = TypeVar("U")
@@ -66,3 +68,13 @@ def deprecate(from_: str, to: str, version: str) -> None:
         DeprecationWarning,
         stacklevel=2,
     )
+
+
+@contextmanager
+def ignore_not_georeferenced() -> Generator[None, None, None]:
+    """Suppress rasterio's warning when opening a dataset that contains no
+    georeferencing information.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=NotGeoreferencedWarning)
+        yield

--- a/tests/core/utils/test_convert.py
+++ b/tests/core/utils/test_convert.py
@@ -5,6 +5,7 @@ from tempfile import TemporaryDirectory
 
 import rasterio
 
+from stactools.core import utils
 from stactools.core.utils.convert import cogify, cogify_subdatasets
 from tests import test_data
 
@@ -35,7 +36,8 @@ class CogifyTest(unittest.TestCase):
     def test_subdataset(self):
         infile = test_data.get_path("data-files/hdf/AMSR_E_L3_RainGrid_B05_200707.h5")
         with TemporaryDirectory() as directory:
-            paths, names = cogify_subdatasets(infile, directory)
+            with utils.ignore_not_georeferenced():
+                paths, names = cogify_subdatasets(infile, directory)
             self.assertEqual(
                 names,
                 [
@@ -45,7 +47,8 @@ class CogifyTest(unittest.TestCase):
             )
             for path in paths:
                 self.assertTrue(os.path.exists(path))
-                with rasterio.open(path) as dataset:
-                    self.assertEqual(
-                        dataset.compression, rasterio.enums.Compression.deflate
-                    )
+                with utils.ignore_not_georeferenced():
+                    with rasterio.open(path) as dataset:
+                        self.assertEqual(
+                            dataset.compression, rasterio.enums.Compression.deflate
+                        )


### PR DESCRIPTION
**Related Issue(s):**
None

**Description:** Used for digging into subdatasets of, e.g., hdf files. Previous art: https://github.com/stactools-packages/viirs/blob/455ca9600c539999a882f5bfc1f20871103470a0/src/stactools/viirs/utils.py#L19-L26

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
