### PR TITLE
v0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added geometry.py for handling common geometrical operations like bounding boxes from GeoJSON ([#314](https://github.com/stac-utils/stactools/pull/314))
+### Changed
+
+### Removed
+
+## [0.4.0] - 2022-08-01
+
+### Added
+
+- `stactools.core.geometry` for handling common geometrical operations like creating bounding boxes from GeoJSON ([#314](https://github.com/stac-utils/stactools/pull/314))
 - Specify installation channel to use for all conda packages to avoid incompatibility ([#301](https://github.com/stac-utils/stactools/pull/301))
 - Allow MultiPolygons when fixing antimeridian issues ([#317](https://github.com/stac-utils/stactools/pull/317))
 - Conda package, via [conda-forge](https://anaconda.org/conda-forge/stactools) ([#324](https://github.com/stac-utils/stactools/pull/324))
 - Context manager to ignore rasterio's NotGeoreferencedWarning ([#331](https://github.com/stac-utils/stactools/pull/331))
-- Added `raster_footprint` module to assist in populating the geometry of an Item from data coverage of its data assets ([#307](https://github.com/stac-utils/stactools/pull/307))
-- `stac add-asset` command to add an asset to an item ([#300](https://github.com/stac-utils/stactools/pull/300))
+- `stactools.core.utils.raster_footprint` and `stac update-geometry`  to assist in populating the geometry of an Item from data coverage of its data assets ([#307](https://github.com/stac-utils/stactools/pull/307))
+- `stactools.core.add_asset` and `stac add-asset` to add an asset to an item ([#300](https://github.com/stac-utils/stactools/pull/300))
 
 ### Changed
 
-- Modified stactools.core.utils.convert with functions to export subdatasets from HDF files as separate COGs and
-single bands from multiband files ([#318](https://github.com/stac-utils/stactools/pull/318))
-- Modified stactools.core.utils.antimeridian.fix_item to return the item and updated 2 unit tests ([#317](https://github.com/stac-utils/stactools/pull/317))
+- Modified `stactools.core.utils.convert` with functions to export subdatasets from HDF files as separate COGs and
+  single bands from multiband files ([#318](https://github.com/stac-utils/stactools/pull/318))
+- Modified `stactools.core.utils.antimeridian.fix_item` to return the item and updated 2 unit tests ([#317](https://github.com/stac-utils/stactools/pull/317))
 - Relaxed typing for cmd parameter for the CliTestCase.run_command in cli_test.py ([#312](https://github.com/stac-utils/stactools/pull/312))
 - Cleaned up API documentation ([#315](https://github.com/stac-utils/stactools/pull/315))
 - Renamed command `addraster` to `add-raster` ([#321](https://github.com/stac-utils/stactools/pull/321))
@@ -283,7 +291,8 @@ See [#9](https://github.com/stac-utils/stactools/pull/9)
 - `stac.cli.command.layout` for modfiygin the layout of STACs
 - `stac.browse` for launching a local instance of stac-browser using docker.
 
-[Unreleased]: <https://github.com/stac-utils/stactools/compare/v0.3.1..main>
+[Unreleased]: <https://github.com/stac-utils/stactools/compare/v0.4.0..main>
+[0.4.0]: <https://github.com/stac-utils/stactools/compare/v0.3.1..v0.4.0>
 [0.3.1]: <https://github.com/stac-utils/stactools/compare/v0.3.0..v0.3.1>
 [0.3.0]: <https://github.com/stac-utils/stactools/compare/v0.2.6..v0.3.0>
 [0.2.6]: <https://github.com/stac-utils/stactools/compare/v0.2.5..v0.2.6>

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -24,9 +24,10 @@ To release a new version of **stactools** or a [stactools-package](https://githu
    If you're in a package, update the appropriate `__init__.py` file.
 7. Update [CHANGELOG.md](CHANGELOG.md):
    1. Change `[Unreleased]` to your new version number and add a date.
-   2. Add a link to your new version at the bottom of the page, e.g. `[0.3.0]: <https://github.com/stac-utils/stactools/compare/v0.2.5..v0.3.0>`.
-   3. Update the `[Unreleased]` link at the bottom of the page to start at your new release.
-   4. Audit your new section of the CHANGELOG to ensure all relevant changes are captured.
+   2. Add a new `[Unreleased]` section at the top of the page with the appropriate subheaders.
+   3. Add a link to your new version at the bottom of the page, e.g. `[0.3.0]: <https://github.com/stac-utils/stactools/compare/v0.2.5..v0.3.0>`.
+   4. Update the `[Unreleased]` link at the bottom of the page to start at your new release.
+   5. Audit your new section of the CHANGELOG to ensure all relevant changes are captured.
 8. Open a pull request for your branch.
    Include a "Release summary" section which includes the contents of your section of the CHANGELOG.
 9. Once approved, merge the branch.

--- a/src/stactools/core/__init__.py
+++ b/src/stactools/core/__init__.py
@@ -24,4 +24,4 @@ __all__ = [
     "move_all_assets",
     "use_fsspec",
 ]
-__version__ = "0.3.1"
+__version__ = "0.4.0"


### PR DESCRIPTION
Includes CHANGELOG and RELEASING fixups.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).

## Annotated tag text

```
v0.4.0

Added:

- `stactools.core.geometry` for handling common geometrical operations like creating bounding boxes from GeoJSON ([#314](https://github.com/stac-utils/stactools/pull/314))
- Specify installation channel to use for all conda packages to avoid incompatibility ([#301](https://github.com/stac-utils/stactools/pull/301))
- Allow MultiPolygons when fixing antimeridian issues ([#317](https://github.com/stac-utils/stactools/pull/317))
- Conda package, via [conda-forge](https://anaconda.org/conda-forge/stactools) ([#324](https://github.com/stac-utils/stactools/pull/324))
- Context manager to ignore rasterio's NotGeoreferencedWarning ([#331](https://github.com/stac-utils/stactools/pull/331))
- `stactools.core.utils.raster_footprint` and `stac update-geometry`  to assist in populating the geometry of an Item from data coverage of its data assets ([#307](https://github.com/stac-utils/stactools/pull/307))
- `stactools.core.add_asset` and `stac add-asset` to add an asset to an item ([#300](https://github.com/stac-utils/stactools/pull/300))

Changed:

- Modified `stactools.core.utils.convert` with functions to export subdatasets from HDF files as separate COGs and
  single bands from multiband files ([#318](https://github.com/stac-utils/stactools/pull/318))
- Modified `stactools.core.utils.antimeridian.fix_item` to return the item and updated 2 unit tests ([#317](https://github.com/stac-utils/stactools/pull/317))
- Relaxed typing for cmd parameter for the CliTestCase.run_command in cli_test.py ([#312](https://github.com/stac-utils/stactools/pull/312))
- Cleaned up API documentation ([#315](https://github.com/stac-utils/stactools/pull/315))
- Renamed command `addraster` to `add-raster` ([#321](https://github.com/stac-utils/stactools/pull/321))

Removed:

- Unnecessary and incorrect `args` and `kwargs` from `StacIO` subclass ([#315](https://github.com/stac-utils/stactools/pull/315))
- Dropped support for Python 3.7 ([#313](https://github.com/stac-utils/stactools/pull/313))
```