### PR TITLE
Release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### [0.4.3] - 2022-12-16
+
 ### Added
 
 - Include kwargs in io `read_text` for use with internal `fsspec.open` call. ([#372](https://github.com/stac-utils/stactools/pull/372))
 - Python 3.11 support ([#376](https://github.com/stac-utils/stactools/pull/376))
 - `stac summary` command ([#323](https://github.com/stac-utils/stactools/pull/323))
-
-### Changed
-
-### Fixed
-
-### Removed
 
 ## [0.4.2] - 2022-09-15
 
@@ -315,7 +311,8 @@ See [#9](https://github.com/stac-utils/stactools/pull/9)
 - `stac.cli.command.layout` for modfiygin the layout of STACs
 - `stac.browse` for launching a local instance of stac-browser using docker.
 
-[Unreleased]: <https://github.com/stac-utils/stactools/compare/v0.4.2..main>
+[Unreleased]: <https://github.com/stac-utils/stactools/compare/v0.4.3..main>
+[0.4.3]: <https://github.com/stac-utils/stactools/compare/v0.4.2..v0.4.3>
 [0.4.2]: <https://github.com/stac-utils/stactools/compare/v0.4.1..v0.4.2>
 [0.4.1]: <https://github.com/stac-utils/stactools/compare/v0.4.0..v0.4.1>
 [0.4.0]: <https://github.com/stac-utils/stactools/compare/v0.3.1..v0.4.0>

--- a/README.md
+++ b/README.md
@@ -58,15 +58,6 @@ To install the single optional dependency:
 pip install stactools[s3]
 ```
 
-### Python 3.10
-
-If you are working in Python 3.10, you'll need to install a pre-release version of rasterio 1.3:
-
-```sh
-pip install --pre rasterio
-pip install stactools
-```
-
 ### Docker
 
 To download the Docker image from the registry:

--- a/src/stactools/core/__init__.py
+++ b/src/stactools/core/__init__.py
@@ -24,4 +24,4 @@ __all__ = [
     "move_all_assets",
     "use_fsspec",
 ]
-__version__ = "0.4.2"
+__version__ = "0.4.3"


### PR DESCRIPTION
**Related Issue(s):**
- Closes #379 

**Description:**
Release v0.4.3. Release notes:

```text
Added:

- Include kwargs in io `read_text` for use with internal `fsspec.open` call. ([#372](https://github.com/stac-utils/stactools/pull/372))
- Python 3.11 support ([#376](https://github.com/stac-utils/stactools/pull/376))
- `stac summary` command ([#323](https://github.com/stac-utils/stactools/pull/323))
```

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
