### PR TITLE
Add geometry and bbox coordinate rounding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `stactools.core.utils.round` for rounding Item geometry and Item and Collection bboxes to a specified precision ([#384](https://github.com/stac-utils/stactools/pull/384))
+
 ### [0.4.3] - 2022-12-16
 
 ### Added

--- a/src/stactools/core/utils/round.py
+++ b/src/stactools/core/utils/round.py
@@ -1,0 +1,48 @@
+from typing import Any, List, TypeVar
+
+from pystac import Collection, Item
+
+# Roughly 1 centimeter in geodetic coordinates
+DEFAULT_PRECISION = 7
+
+S = TypeVar("S", Item, Collection)
+
+
+def round_coordinates(stac_object: S, precision: int = DEFAULT_PRECISION) -> S:
+    """Rounds Item geometry and bbox coordinates or Collection spatial extent
+    bbox coordinates to specified precision.
+
+    Any tuples encountered will be converted to lists.
+
+    Args:
+        stac_object (S): A pystac Item or Collection.
+        precision (int): Number of decimal places for rounding.
+
+    Returns:
+        S: The original PySTAC Item or Collection, with rounded coordinates.
+    """
+
+    def recursive_round(coordinates: List[Any], precision: int) -> List[Any]:
+        for idx, value in enumerate(coordinates):
+            if isinstance(value, (int, float)):
+                coordinates[idx] = round(value, precision)
+            else:
+                coordinates[idx] = list(value)  # handle any tuples
+                coordinates[idx] = recursive_round(coordinates[idx], precision)
+        return coordinates
+
+    if isinstance(stac_object, Item):
+        if stac_object.geometry is not None:
+            stac_object.geometry["coordinates"] = recursive_round(
+                list(stac_object.geometry["coordinates"]), precision
+            )
+
+        if stac_object.bbox is not None:
+            stac_object.bbox = recursive_round(list(stac_object.bbox), precision)
+
+    elif isinstance(stac_object, Collection):
+        stac_object.extent.spatial.bboxes = recursive_round(
+            list(stac_object.extent.spatial.bboxes), precision
+        )
+
+    return stac_object

--- a/tests/core/utils/test_round.py
+++ b/tests/core/utils/test_round.py
@@ -1,0 +1,68 @@
+from pystac import Collection, Item
+
+from stactools.core.utils.round import round_coordinates
+from tests import test_data
+
+
+def test_item_geometry_bbox() -> None:
+    item = Item.from_file(
+        test_data.get_path(
+            "data-files/catalogs/test-case-1/country-1/area-1-1/"
+            "area-1-1-imagery/area-1-1-imagery.json"
+        )
+    )
+    item = round_coordinates(item, precision=5)
+
+    polys = item.geometry["coordinates"]
+    for poly in polys:
+        for coord in poly:
+            for value in coord:
+                assert str(value)[::-1].find(".") <= 5
+
+    bbox = item.bbox
+    for value in bbox:
+        assert str(value)[::-1].find(".") <= 5
+
+
+def test_item_multipolygon_geometry() -> None:
+    item = Item.from_file(
+        test_data.get_path("data-files/catalogs/test-case-4/dar/42f235/42f235.json")
+    )
+    item = round_coordinates(item, precision=5)
+
+    polys = item.geometry["coordinates"]
+    for poly in polys:
+        for subpoly in poly:
+            for coord in subpoly:
+                for value in coord:
+                    assert str(value)[::-1].find(".") <= 5
+
+    bbox = item.bbox
+    for value in bbox:
+        assert str(value)[::-1].find(".") <= 5
+
+
+def test_item_no_geometry_or_bbox() -> None:
+    item = Item.from_file(
+        test_data.get_path(
+            "data-files/catalogs/test-case-1/country-1/area-1-1/"
+            "area-1-1-imagery/area-1-1-imagery.json"
+        )
+    )
+    item.bbox = None
+    item.geometry = None
+    item = round_coordinates(item, precision=5)
+    assert isinstance(item, Item)
+
+
+def test_collection_bbox() -> None:
+    collection = Collection.from_file(
+        test_data.get_path(
+            "data-files/catalogs/test-case-1/country-1/area-1-1/collection.json"
+        )
+    )
+    collection = round_coordinates(collection, precision=5)
+    coords = collection.extent.spatial.bboxes
+    for coord in coords:
+        for value in coord:
+            assert str(value)[::-1].find(".") <= 5


### PR DESCRIPTION
**Related Issue(s):**
None.

**Description:**
The coordinates in Item geometries and bboxes and Collection extent bboxes often contain excess precision, much greater than 7 or 8 decimal places (which is roughly centimeter to millimeter level). This PR provides a utility to round coordinates to a specified precision. This saves a small amount of space when storing STAC, provides more consistent and clean looking STAC, and removes implications of extreme location accuracy (e.g., 12 decimal places implies accuracy to sub-micrometer level).

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [ ] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
