### PR TITLE
Disallow sphinx 6

### DIFF
--- a/.readthedocs.environment.yml
+++ b/.readthedocs.environment.yml
@@ -18,7 +18,7 @@ dependencies:
       - nbsphinx
       - pydata-sphinx-theme
       - pylint
-      - sphinx
+      - sphinx < 6
       - sphinx-autobuild
       - sphinx-click
       - sphinxcontrib-napoleon

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,7 @@ pydata-sphinx-theme
 pylint
 pytest
 pytest-cov
-sphinx
+sphinx < 6
 sphinx-autobuild
 sphinx-click
 sphinxcontrib-napoleon


### PR DESCRIPTION
**Description:**
It breaks docs building, e.g. https://readthedocs.org/projects/stactools/builds/19065777/.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
