### PR TITLE
Expose recursive_round function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `stactools.core.utils.round` for rounding Item geometry and Item and Collection bboxes to a specified precision ([#384](https://github.com/stac-utils/stactools/pull/384))
 
+### Changed
+
+- Freed `recursive_round` function from `round_coordinates` in `stactools.core.utils.round` ([#390](https://github.com/stac-utils/stactools/pull/390))
+
 ### [0.4.3] - 2022-12-16
 
 ### Added

--- a/src/stactools/core/utils/round.py
+++ b/src/stactools/core/utils/round.py
@@ -12,8 +12,6 @@ def round_coordinates(stac_object: S, precision: int = DEFAULT_PRECISION) -> S:
     """Rounds Item geometry and bbox coordinates or Collection spatial extent
     bbox coordinates to specified precision.
 
-    Any tuples encountered will be converted to lists.
-
     Args:
         stac_object (S): A pystac Item or Collection.
         precision (int): Number of decimal places for rounding.
@@ -21,16 +19,6 @@ def round_coordinates(stac_object: S, precision: int = DEFAULT_PRECISION) -> S:
     Returns:
         S: The original PySTAC Item or Collection, with rounded coordinates.
     """
-
-    def recursive_round(coordinates: List[Any], precision: int) -> List[Any]:
-        for idx, value in enumerate(coordinates):
-            if isinstance(value, (int, float)):
-                coordinates[idx] = round(value, precision)
-            else:
-                coordinates[idx] = list(value)  # handle any tuples
-                coordinates[idx] = recursive_round(coordinates[idx], precision)
-        return coordinates
-
     if isinstance(stac_object, Item):
         if stac_object.geometry is not None:
             stac_object.geometry["coordinates"] = recursive_round(
@@ -46,3 +34,27 @@ def round_coordinates(stac_object: S, precision: int = DEFAULT_PRECISION) -> S:
         )
 
     return stac_object
+
+
+def recursive_round(coordinates: List[Any], precision: int) -> List[Any]:
+    """Rounds a list of numbers. The list can contain additional nested lists or
+    tuples of numbers.
+
+    Any tuples encountered will be converted to lists.
+
+    Args:
+        coordinates (List[Any]): A list of numbers, possibly containing nested
+            lists or tuples of numbers.
+        precision (int): Number of decimal places to use for rounding.
+
+    Returns:
+        List[Any]: a list (possibly nested) of numbers rounded to the given
+            precision.
+    """
+    for idx, value in enumerate(coordinates):
+        if isinstance(value, (int, float)):
+            coordinates[idx] = round(value, precision)
+        else:
+            coordinates[idx] = list(value)  # handle any tuples
+            coordinates[idx] = recursive_round(coordinates[idx], precision)
+    return coordinates

--- a/tests/core/utils/test_round.py
+++ b/tests/core/utils/test_round.py
@@ -1,6 +1,8 @@
+from typing import Any, Iterable, Iterator
+
 from pystac import Collection, Item
 
-from stactools.core.utils.round import round_coordinates
+from stactools.core.utils.round import recursive_round, round_coordinates
 from tests import test_data
 
 
@@ -66,3 +68,34 @@ def test_collection_bbox() -> None:
     for coord in coords:
         for value in coord:
             assert str(value)[::-1].find(".") <= 5
+
+
+def test_recursive_round() -> None:
+    def flatten(nested: Iterable) -> Iterator[Any]:
+        for value in nested:
+            if isinstance(value, Iterable):
+                for nest in flatten(value):
+                    yield nest
+            else:
+                yield value
+
+    vanilla = [0.123456, 1.12345678]
+    rounded = recursive_round(vanilla, precision=4)
+    for coord in rounded:
+        assert str(coord)[::-1].find(".") == 4
+
+    nested_lists = [
+        [[0.123456, 2.1234567], [1.12345678, 2.12345]],
+        [[0.123456, 1.12345678]],
+    ]
+    rounded = recursive_round(nested_lists, precision=3)
+    for coord in flatten(rounded):
+        assert str(coord)[::-1].find(".") == 3
+
+    nested_tuples = [
+        ((0.123456, 2.1234567), (1.12345678, 2.12345)),
+        ((0.123456, 1.12345678)),
+    ]
+    rounded = recursive_round(nested_tuples, precision=5)
+    for coord in flatten(rounded):
+        assert str(coord)[::-1].find(".") == 5


### PR DESCRIPTION
**Related Issue(s):**
None

**Description:**
Pulls the `recursive_round()` function out of `round_coordinates()`. Being able to access `recursive_round` directly is useful in cases, e.g., where you'd like to round coordinates prior to creating an Item or Collection.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [ ] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
