### PR TITLE
Remove dependabot checks for pip dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,14 +3,9 @@ updates:
   - package-ecosystem: "docker"
     directory: "/docker"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
-
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "daily"
+      interval: "weekly"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Update
         run: scripts/update
       - name: Install pre-release versions of rasterio and pystac
-        run: pip install -U --pre pystac rasterio
+        run: pip install -U --pre pystac rasterio --no-binary rasterio
       - name: Run tests
         run: scripts/test
   codecov:


### PR DESCRIPTION
**Related Issue(s):**

- Closes #400 

**Description:**

I was spending a lot of time just auto-closing dependabot version bumps to `requirements-min.txt` (e.g. this morning: https://github.com/stac-utils/stactools/pull/399). The whole point behind `requirements-min.txt` is that we _don't_ have to update our version files every time there's a release; for more information behind this strategy, here's [a blog post I wrote](https://www.gadom.ski/2022/02/18/dependency-protection-with-python-and-github-actions.html). Without `requirements-min.txt`, and because dependabot [doesn't understand `setup.cfg`](https://github.com/dependabot/dependabot-core/issues/2133), there really isn't much value in checking the `pip` package ecosystem, so I've removed it.

Also sets our other checks to weekly, we don't really need a daily cadence for this repo.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [ ] Documentation has been updated to reflect changes, if applicable.
- [ ] Changes are added to the [CHANGELOG](../CHANGELOG.md).
