### PR TITLE
Add codeowners and a note in the readme

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @gadomski

--- a/README.md
+++ b/README.md
@@ -229,6 +229,11 @@ You can also run the previous commands in the docker container using:
 docker/console
 ```
 
+### Code owners and repository maintainer(s)
+
+This repository uses a [code owners file](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) to automatically request reviews for new pull requests.
+The current primary maintainer(s) of this repository are listed under the `*` rule in the [CODEOWNERS](./CODEOWNERS) file.
+
 ### Adding a new package
 
 To create a new `stactools` package, use the [`stactools` package template](https://github.com/stactools-packages/template).


### PR DESCRIPTION
**Description:**
I'd like to test out using CODEOWNERS to automatically request reviews, and as an implicit statement of the current repository maintainer(s). I figured I'd start on **stactools**, and then push it down to **pystac-client** and **pystac** (and maybe **stac-fastapi**).

I don't think this PR needs a changelog entry.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [ ] Changes are added to the [CHANGELOG](../CHANGELOG.md).
