### PR TITLE
Ceil jsonschema

### DIFF
--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -3,6 +3,7 @@ aiohttp == 3.8.3
 click == 8.1.3
 fsspec == 2021.7
 lxml == 4.9.2
+jsonschema == 4.0.1
 numpy == 1.22.0
 pyproj == 3.3
 pystac[validation] == 1.6.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,21 @@ install_requires =
     aiohttp >= 3.8.3
     click >= 8.1.3
     fsspec >= 2021.7
+    # Long story.
+    #
+    # - stac-check 1.3.1 depends on a beta version of jsonschema
+    # - jsonschema released an alpha version of 4.18 that thinks that schemas
+    #   with empty fragments are invalid
+    # - Pretty much all the STAC schemas have empty fragments
+    # - Because stac-check depends on a pre-release, this enables pre-releases
+    #   of jsonschema for any python environment w/ stac-check
+    #
+    # Until this is resolved (https://github.com/stac-utils/stac-check/pull/105)
+    # we need to ceil our jsonschema version so we don't break environments
+    # downstream.
+    #
+    # - @gadomski 2023-03-23
+    jsonschema >= 4.0.1, < 4.18
     lxml >= 4.9.2
     numpy >= 1.22.0
     pyproj >= 3.3


### PR DESCRIPTION
**Related Issue(s):**

- Required until https://github.com/stac-utils/stac-check/pull/105 is released

**Description:**
- stac-check 1.3.1 [depends on a beta version of jsonschema](https://github.com/stac-utils/stac-check/blob/a3a8c3928e034048fc90186947efec7a22951d05/setup.py#L20)
- jsonschema [released an alpha version of 4.18](https://github.com/python-jsonschema/jsonschema/releases/tag/v4.18.0a2) that thinks that [schemas with empty fragments are invalid](https://github.com/python-jsonschema/jsonschema/issues/1064#issuecomment-1478404924)
- Pretty much all the STAC schemas have [empty fragments](https://schemas.stacspec.org/v1.0.0/collection-spec/json-schema/collection.json)
- Because stac-check depends on a pre-release, this enables [pre-releases of jsonschema for any python environment w/ stac-check](https://pip.pypa.io/en/stable/cli/pip_install/#pre-release-versions)

Until this is resolved we need to ceil our jsonschema version so we don't break environments downstream. I don't think we need a CHANGELOG entry for this. After merge, we should release either a post or a new BUGFIX version to propagate this fix to PyPI.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [ ] Changes are added to the [CHANGELOG](../CHANGELOG.md).
