### PR TITLE
Strip spaces and '/' from subdataset names

### DIFF
--- a/src/stactools/core/utils/convert.py
+++ b/src/stactools/core/utils/convert.py
@@ -108,8 +108,11 @@ def cogify_subdatasets(
                 subdataset_name = parts[-1]
                 if subdataset_names and subdataset_name not in subdataset_names:
                     continue
-                sanitized_subdataset_name = subdataset_name.replace(" ", "_").replace(
-                    "/", "_"
+                sanitized_subdataset_name = (
+                    subdataset_name.strip()
+                    .strip("/")
+                    .replace(" ", "_")
+                    .replace("/", "_")
                 )
                 names.append(sanitized_subdataset_name)
                 file_name = f"{base_file_name}_{sanitized_subdataset_name}.tif"

--- a/tests/core/utils/test_convert.py
+++ b/tests/core/utils/test_convert.py
@@ -39,11 +39,11 @@ class CogifyTest(unittest.TestCase):
             with utils.ignore_not_georeferenced():
                 paths, names = cogify_subdatasets(infile, directory)
             self.assertEqual(
-                names,
-                [
-                    "__MonthlyRainTotal_GeoGrid_Data_Fields_RrLandRain",
-                    "__MonthlyRainTotal_GeoGrid_Data_Fields_TbOceanRain",
-                ],
+                set(names),
+                {
+                    "MonthlyRainTotal_GeoGrid_Data_Fields_RrLandRain",
+                    "MonthlyRainTotal_GeoGrid_Data_Fields_TbOceanRain",
+                },
             )
             for path in paths:
                 self.assertTrue(os.path.exists(path))


### PR DESCRIPTION
**Description:**
I was finding that different hdf library versions produced different numbers of `/` at the front end, so I figure it's safer to just clean the front and the back of the subdataset names. They look better now, too.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [ ] Documentation has been updated to reflect changes, if applicable.
- [ ] Changes are added to the [CHANGELOG](../CHANGELOG.md).
