### PR TITLE
Bump stac-check to 1.3.2

### DIFF
--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -9,5 +9,5 @@ pyproj == 3.3
 pystac[validation] == 1.6.1
 rasterio == 1.3.2
 requests == 2.27.1
-stac-check == 1.2.0
+stac-check == 1.3.2
 stac-validator == 3.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,28 +37,13 @@ install_requires =
     aiohttp >= 3.8.3
     click >= 8.1.3
     fsspec >= 2021.7
-    # Long story.
-    #
-    # - stac-check 1.3.1 depends on a beta version of jsonschema
-    # - jsonschema released an alpha version of 4.18 that thinks that schemas
-    #   with empty fragments are invalid
-    # - Pretty much all the STAC schemas have empty fragments
-    # - Because stac-check depends on a pre-release, this enables pre-releases
-    #   of jsonschema for any python environment w/ stac-check
-    #
-    # Until this is resolved (https://github.com/stac-utils/stac-check/pull/105)
-    # we need to ceil our jsonschema version so we don't break environments
-    # downstream.
-    #
-    # - @gadomski 2023-03-23
-    jsonschema >= 4.0.1, < 4.18
     lxml >= 4.9.2
     numpy >= 1.22.0
     pyproj >= 3.3
     pystac[validation] >= 1.6.1
     rasterio >= 1.3.2
     requests >= 2.27.1
-    stac-check >= 1.2.0
+    stac-check >= 1.3.2
     stac-validator >= 3.1.0
 
 [options.extras_require]


### PR DESCRIPTION
**Description:**
Fixes the jsonschema pre-release issue. CHANGELOG entry not required.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [ ] Documentation has been updated to reflect changes, if applicable.
- [ ] Changes are added to the [CHANGELOG](../CHANGELOG.md).
