### PR TITLE
feat: update bbox when updating geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `densify_by_factor` now includes the final coordinate in the original coordinate list in the returned densifed coordinate list ([#412](https://github.com/stac-utils/stactools/pull/412))
 - The `footprint` method on the `RasterFootprint` class now always returns counter-clockwise polygons in line with the GeoJSON specification ([#412](https://github.com/stac-utils/stactools/pull/412))
 
+### Changed
+
+- `update_geometry_from_asset_footprint` in the raster_footprint module now updates the Item bbox based on the updated geometry extents ([#414](https://github.com/stac-utils/stactools/pull/414))
+
 ## [0.4.5] - 2023-03-24
 
 ### Added

--- a/src/stactools/core/utils/raster_footprint.py
+++ b/src/stactools/core/utils/raster_footprint.py
@@ -506,6 +506,8 @@ class RasterFootprint:
         """Accepts an Item and an optional list of asset names within that
         Item, and updates the geometry of that Item in-place with the data
         footprint derived from the first of the assets that exists in the Item.
+        The Item bbox is also updated in-place to bound the new footprint
+        extents.
 
         See :class:`RasterFootprint` for details on the data footprint
         calculation.
@@ -565,6 +567,7 @@ class RasterFootprint:
         if asset_name_and_extent is not None:
             _, extent = asset_name_and_extent
             item.geometry = extent
+            item.bbox = list(shape(extent).bounds)
             return True
         else:
             return False
@@ -680,7 +683,8 @@ def update_geometry_from_asset_footprint(
 
     Accepts an Item and an optional list of asset names within that Item, and
     updates the geometry of that Item in-place with the data footprint derived
-    from the first of the assets that exists in the Item.
+    from the first of the assets that exists in the Item. The Item bbox is also
+    updated in-place to bound the new footprint extents.
 
     See :class:`RasterFootprint` for details on the data footprint
     calculation.


### PR DESCRIPTION
**Related Issue(s):**
- Closes #413 

**Description:**
When using the `update_geometry_from_asset_footprint` method, it is easy to forget that an updated Item geometry usually requires that the Item bbox also be updated. This PR adds that functionality.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [ ] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
