### PR TITLE
Add `enclose_poles` to antimeridian module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `enclose_poles` to the antimeridian module ([#416](https://github.com/stac-utils/stactools/pull/416))
+
 ### Fixed
 
 - `densify_by_distance` now includes the points in the original coordinate list in the returned densified coordinate list ([#412](https://github.com/stac-utils/stactools/pull/412))


### PR DESCRIPTION
**Related Issue(s):**
- Required for https://github.com/microsoft/planetary-computer-tasks/pull/167

**Description:**
Items whose assets include data over the poles can be hard to represent in WGS84, which is required for their geometries. This PR adds a new function, `stactools.core.utils.antimeridian.enclose_poles`, that modifies geometries that cross the antimerdian to enclose the polar regions.

## Explanation

Here's some sentinel5p data:

![image](https://user-images.githubusercontent.com/58314/230909073-7f9ca744-8921-44be-b6bc-490e707ea94f.png)

As you can see, the data encloses both the north and the south poles. A simple geometry will follow the boundary of the data, but doesn't display (or really make sense at all) on a map:

![Screenshot 2023-04-10 at 7 22 43 AM](https://user-images.githubusercontent.com/58314/230909247-955c3bd1-d47c-4ab7-b5d5-549fc6f332d4.png)

To solve the problem, we can "box" the poles by detecting antimeridian crossings and adding points to cover the polar regions in WGS84:

![Screenshot 2023-04-10 at 7 23 38 AM](https://user-images.githubusercontent.com/58314/230909389-03a19eb0-7ec9-4f2c-8586-2527ebfaf69d.png)

This last image shows a geometry created with `enclose_poles`.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
