### PR TITLE
Decrease raster footprint memory use

### DIFF
--- a/src/stactools/core/utils/raster_footprint.py
+++ b/src/stactools/core/utils/raster_footprint.py
@@ -259,7 +259,7 @@ class RasterFootprint:
             if np.isnan(self.no_data):
                 mask[~np.isnan(self.data_array)] = 1
             else:
-                mask[np.where(self.data_array != self.no_data)] = 1
+                mask[self.data_array != self.no_data] = 1
             mask = np.sum(mask, axis=0, dtype=np.uint8)
             mask[mask > 0] = 1
         else:


### PR DESCRIPTION
**Related Issue(s):**

- Closes #427 

**Description:**

One-liner that removes `np.where` that enclosed a boolean array. For an ESA WorldCover tile (36,000x36,000 pixels in size), the memory required to populate the initial mask array (all 0s) with 1s at valid data locations is reduced from ~17 GB to ~ 1GB.

No API changes, so no CHANGELOG entry required.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [ ] Documentation has been updated to reflect changes, if applicable.
- [ ] Changes are added to the [CHANGELOG](../CHANGELOG.md).
