### PR TITLE
Add `skip-resolve` argument for skipping over pulling external files

### DIFF
--- a/src/stactools/cli/commands/copy.py
+++ b/src/stactools/cli/commands/copy.py
@@ -68,7 +68,7 @@ def create_copy_command(cli: click.Group) -> click.Command:
         "--copy-assets",
         "-a",
         is_flag=True,
-        help=("Copy all item assets to " "be alongside the new item location."),
+        help="Copy all item assets to be alongside the new item location.",
     )
     @click.option(
         "-l",
@@ -78,12 +78,21 @@ def create_copy_command(cli: click.Group) -> click.Command:
             "instead of the destination folder."
         ),
     )
+    @click.option(
+        "--skip-resolve",
+        is_flag=True,
+        help=(
+            "Skip resolving HREF links. Use this flag to avoid writing external "
+            "child objects locally."
+        ),
+    )
     def copy_command(
         src: str,
         dst: str,
         catalog_type: pystac.CatalogType,
         copy_assets: bool,
         publish_location: Optional[str],
+        skip_resolve: bool,
     ) -> None:
         """Copy a STAC Catalog or Collection at SRC to the directory at DST.
 
@@ -92,6 +101,13 @@ def create_copy_command(cli: click.Group) -> click.Command:
         source_catalog = pystac.read_file(make_absolute_href(src))
         if not isinstance(source_catalog, pystac.Catalog):
             raise click.BadArgumentUsage(f"{src} is not a STAC Catalog")
-        copy_catalog(source_catalog, dst, catalog_type, copy_assets, publish_location)
+        copy_catalog(
+            source_catalog,
+            dst,
+            catalog_type,
+            copy_assets,
+            publish_location,
+            skip_resolve,
+        )
 
     return copy_command

--- a/src/stactools/core/copy.py
+++ b/src/stactools/core/copy.py
@@ -230,16 +230,22 @@ def copy_catalog(
     catalog_type: Optional[CatalogType] = None,
     copy_assets: bool = False,
     publish_location: Optional[str] = None,
+    skip_resolve: bool = False,
 ) -> None:
-    catalog = source_catalog.full_copy()
+    if skip_resolve:
+        catalog = source_catalog.clone()
+        catalog.set_root(catalog)
+    else:
+        catalog = source_catalog.full_copy()
+
     dest_directory = make_absolute_href(dest_directory)
 
     if copy_assets:
         catalog = move_all_assets(catalog, copy=True, make_hrefs_relative=True)
 
     if publish_location is not None:
-        catalog.normalize_hrefs(publish_location)
+        catalog.normalize_hrefs(publish_location, skip_unresolved=skip_resolve)
         catalog.save(catalog_type, dest_directory)
     else:
-        catalog.normalize_hrefs(dest_directory)
+        catalog.normalize_hrefs(dest_directory, skip_unresolved=skip_resolve)
         catalog.save(catalog_type)

--- a/tests/cli/commands/test_copy.py
+++ b/tests/cli/commands/test_copy.py
@@ -7,6 +7,8 @@ from pystac.utils import is_absolute_href, make_absolute_href
 from stactools.cli.commands.copy import create_copy_command, create_move_assets_command
 from stactools.testing import CliTestCase
 
+from tests import test_data
+
 from .test_cases import TestCases
 
 
@@ -108,3 +110,9 @@ class CopyTest(CliTestCase):
                     )
 
                     self.assertEqual(common_path, os.path.dirname(item_href))
+
+    def test_copy_using_skip_resolve(self) -> None:
+        path = test_data.get_path("data-files/catalogs/external-child/catalog.json")
+        with TemporaryDirectory() as tmp_dir:
+            self.run_command(["copy", path, tmp_dir, "--skip-resolve"])
+            self.assertEqual(os.listdir(tmp_dir), ["catalog.json"])

--- a/tests/data-files/catalogs/external-child/catalog.json
+++ b/tests/data-files/catalogs/external-child/catalog.json
@@ -1,0 +1,26 @@
+{
+  "type": "Catalog",
+  "id": "test",
+  "stac_version": "1.0.0",
+  "description": "test",
+  "links": [
+    {
+      "rel": "self",
+      "href": "/home/jsignell/stactools/catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "root",
+      "href": "/home/jsignell/stactools/catalog.json",
+      "type": "application/json",
+      "title": "test"
+    },
+    {
+      "rel": "child",
+      "href": "https://raw.githubusercontent.com/radiantearth/stac-spec/v1.0.0/examples/collection.json",
+      "type": "application/json",
+      "title": "Simple Example Collection"
+    }
+  ],
+  "title": "test"
+}


### PR DESCRIPTION
Before you submit a pull request, please fill in the following:

**Related Issue(s):**
Closes #418 

**Description:**
I added a `skip-resolve` flag for copy that lets users decide whether or not to resolve links to their full pystac object representation. Some other options for this names are: `skip-unresolved-links` or `ignore-links` 

![Screenshot from 2023-05-30 17-20-34](https://github.com/stac-utils/stactools/assets/4806877/f0dba8ee-70b2-4456-9b36-6f83acc90d43)

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [ ] Changes are added to the [CHANGELOG](../CHANGELOG.md).
