### PR TITLE
`reproject_shape` without precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `reproject_shape` without a precision ([#454](https://github.com/stac-utils/stactools/pull/454))
+
 ## [0.5.0] - 2023-08-04
 
 ### Added

--- a/src/stactools/core/projection.py
+++ b/src/stactools/core/projection.py
@@ -49,6 +49,8 @@ def reproject_shape(
     Returns:
         geom: the reprojected shapely geometry object
     """
+    if precision is None:
+        precision = -1  # rasterio uses -1 for "unspecified"
     return remove_repeated_points(
         shape(transform_geom(src_crs, dst_crs, geom, precision=precision))
     )

--- a/tests/core/test_projection.py
+++ b/tests/core/test_projection.py
@@ -1,0 +1,7 @@
+from shapely.geometry import Point
+from stactools.core import projection
+
+
+def test_no_precision() -> None:
+    # This errors in stactools v0.5.0 because precision is None (needs to be an integer)
+    projection.reproject_shape("EPSG:4326", "EPSG:4326", Point((0, 0)))


### PR DESCRIPTION
**Description:**
Introduced in #441. Discovered when working in a [downstream](https://github.com/stactools-packages/sentinel2).

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [ ] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
