### PR TITLE
Don't use deprecated methods from pystac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `reproject_shape` without a precision ([#454](https://github.com/stac-utils/stactools/pull/454))
+- Don't use deprecated `Catalog.get_all_items` ([#455](https://github.com/stac-utils/stactools/pull/455))
 
 ## [0.5.0] - 2023-08-04
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,3 +96,6 @@ warn_unused_ignores = true
 [[tool.mypy.overrides]]
 module = ["fsspec", "osgeo", "rasterio", "s3fs", "shapely"]
 ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+filterwarnings = ["error:::pystac[.*]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,17 +4,11 @@ description = "Command line tool and Python library for working with STAC"
 readme = "README.md"
 authors = [
     { name = "Rob Emanuele", email = "rdemanuele@gmail.com" },
-    { name = "Pete Gadomski", email =  "pete.gadomski@gmail.com" },
+    { name = "Pete Gadomski", email = "pete.gadomski@gmail.com" },
 ]
-maintainers = [{ name = "Pete Gadomski", email =  "pete.gadomski@gmail.com" }]
+maintainers = [{ name = "Pete Gadomski", email = "pete.gadomski@gmail.com" }]
 license = { text = "Apache-2.0" }
-keywords = [
-    "pystac",
-    "imagery",
-    "raster",
-    "catalog",
-    "STAC",
-]
+keywords = ["pystac", "imagery", "raster", "catalog", "STAC"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "License :: OSI Approved :: Apache Software License",
@@ -100,11 +94,5 @@ strict = true
 warn_unused_ignores = true
 
 [[tool.mypy.overrides]]
-module = [
-    "fsspec",
-    "osgeo",
-    "rasterio",
-    "s3fs",
-    "shapely"
-]
+module = ["fsspec", "osgeo", "rasterio", "s3fs", "shapely"]
 ignore_missing_imports = true

--- a/src/stactools/core/add.py
+++ b/src/stactools/core/add.py
@@ -22,7 +22,7 @@ def add_item(
         move_assets (bool): If true, move the asset files alongside the target item.
     """
 
-    target_item_ids = [item.id for item in target_catalog.get_all_items()]
+    target_item_ids = [item.id for item in target_catalog.get_items(recursive=True)]
     if source_item.id in target_item_ids:
         raise ValueError(
             f"An item with ID {source_item.id} already exists in the target catalog"

--- a/src/stactools/core/copy.py
+++ b/src/stactools/core/copy.py
@@ -259,7 +259,7 @@ def move_all_assets(
             the catalog or collection.
     """
 
-    for item in catalog.get_all_items():
+    for item in catalog.get_items(recursive=True):
         move_assets(
             item, asset_subdirectory, make_hrefs_relative, copy, ignore_conflicts
         )

--- a/src/stactools/core/layout.py
+++ b/src/stactools/core/layout.py
@@ -46,7 +46,7 @@ def layout_catalog(
     """
 
     if remove_existing_subcatalogs:
-        items = catalog.get_all_items()
+        items = catalog.get_items(recursive=True)
         for item in items:
             parent = item.get_parent()
             assert parent is not None

--- a/src/stactools/core/merge.py
+++ b/src/stactools/core/merge.py
@@ -108,7 +108,7 @@ def merge_all_items(
     Returns:
         pystac.Catalog or pystac.Collection: The ``target_catalog``
     """
-    source_items = source_catalog.get_all_items()
+    source_items = source_catalog.get_items(recursive=True)
     ids_to_items = {item.id: item for item in source_items}
 
     parent_dir = os.path.dirname(target_catalog.self_href)
@@ -128,7 +128,7 @@ def merge_all_items(
         source_catalog = new_source_catalog
         target_catalog.add_child(source_catalog, source_catalog.title)
     else:
-        for item in target_catalog.get_all_items():
+        for item in target_catalog.get_items(recursive=True):
             source_item = ids_to_items.get(item.id)
             if source_item is not None:
                 merge_items(

--- a/tests/cli/commands/test_add.py
+++ b/tests/cli/commands/test_add.py
@@ -18,7 +18,7 @@ def item_path() -> str:
 def test_add_item(item_path: str, tmp_planet_disaster: pystac.Collection):
     collection = tmp_planet_disaster
     collection_path = collection.get_self_href()
-    items = list(collection.get_all_items())
+    items = list(collection.get_items(recursive=True))
     assert len(items) == 5
 
     runner = CliRunner()
@@ -26,7 +26,7 @@ def test_add_item(item_path: str, tmp_planet_disaster: pystac.Collection):
     assert result.exit_code == 0
 
     collection_after = pystac.read_file(collection_path)
-    items = list(collection_after.get_all_items())
+    items = list(collection_after.get_items(recursive=True))
     assert len(items) == 6
 
 
@@ -35,7 +35,7 @@ def test_add_item_to_specific_collection(
 ):
     collection = tmp_planet_disaster
     collection_path = collection.get_self_href()
-    items = list(collection.get_all_items())
+    items = list(collection.get_items(recursive=True))
     assert len(items) == 5
     item_before = pystac.read_file(item_path)
 
@@ -62,7 +62,7 @@ def test_add_item_to_missing_collection(
 ):
     collection = tmp_planet_disaster
     collection_path = collection.get_self_href()
-    items = list(collection.get_all_items())
+    items = list(collection.get_items(recursive=True))
     assert len(items) == 5
 
     runner = CliRunner()

--- a/tests/cli/commands/test_add_raster.py
+++ b/tests/cli/commands/test_add_raster.py
@@ -9,7 +9,7 @@ from tests.conftest import expected_json
 def test_add_raster_to_items(tmp_planet_disaster: pystac.Collection):
     collection = tmp_planet_disaster
     collection_path = collection.get_self_href()
-    items = list(collection.get_all_items())
+    items = list(collection.get_items(recursive=True))
     item_path = pystac.utils.make_absolute_href(
         items[0].get_self_href(), collection_path
     )
@@ -19,7 +19,7 @@ def test_add_raster_to_items(tmp_planet_disaster: pystac.Collection):
     assert result.exit_code == 0
 
     updated = pystac.read_file(collection_path)
-    item = list(updated.get_all_items())[0]
+    item = list(updated.get_items(recursive=True))[0]
     asset = item.get_assets().get("analytic")
     assert asset is not None
     expected = expected_json("rasterbands.json")

--- a/tests/cli/commands/test_copy.py
+++ b/tests/cli/commands/test_copy.py
@@ -11,14 +11,14 @@ from tests import test_data
 
 def test_copy(tmp_path: Path, planet_disaster: pystac.Collection) -> None:
     collection_path = planet_disaster.get_self_href()
-    item_ids = set([i.id for i in planet_disaster.get_all_items()])
+    item_ids = set([i.id for i in planet_disaster.get_items(recursive=True)])
 
     runner = CliRunner()
     result = runner.invoke(cli, ["copy", collection_path, str(tmp_path)])
     assert result.exit_code == 0
 
     copy_cat = pystac.read_file(tmp_path / "collection.json")
-    copy_cat_ids = set([i.id for i in copy_cat.get_all_items()])
+    copy_cat_ids = set([i.id for i in copy_cat.get_items(recursive=True)])
 
     assert copy_cat_ids == item_ids
 
@@ -34,7 +34,7 @@ def test_copy_to_relative(tmp_path: Path, planet_disaster: pystac.Collection) ->
     assert result.exit_code == 0
 
     dst_cat = pystac.read_file(dst_dir / "collection.json")
-    for item in dst_cat.get_all_items():
+    for item in dst_cat.get_items(recursive=True):
         item_href = item.get_self_href()
         for asset in item.assets.values():
             href = asset.href
@@ -96,7 +96,7 @@ def test_move_assets(tmp_path: Path, planet_disaster: pystac.Collection) -> None
     assert result.exit_code == 0
 
     cat2 = pystac.read_file(cat_href)
-    for item in cat2.get_all_items():
+    for item in cat2.get_items(recursive=True):
         item_href = item.get_self_href()
         for asset in item.assets.values():
             href = asset.href
@@ -121,7 +121,7 @@ def test_copy_assets(tmp_path: Path, planet_disaster: pystac.Collection) -> None
     assert result.exit_code == 0
 
     cat2 = pystac.read_file(tmp_path / "collection.json")
-    for item in cat2.get_all_items():
+    for item in cat2.get_items(recursive=True):
         assert all(v.href.startswith("./") for v in item.assets.values())
 
     assert (

--- a/tests/cli/commands/test_merge.py
+++ b/tests/cli/commands/test_merge.py
@@ -25,7 +25,7 @@ def two_planet_disaster_subsets(tmp_path: Path):
         col = pystac.Collection.from_file(
             test_data.get_path("data-files/planet-disaster/collection.json")
         )
-        for item in list(col.get_all_items()):
+        for item in list(col.get_items(recursive=True)):
             if item.id != item_id:
                 item.get_parent().remove_item(item.id)
         col.update_extent_from_items()
@@ -47,7 +47,7 @@ def test_merge_moves_assets(two_planet_disaster_subsets: List[str]):
 
     target_col = pystac.read_file(col_paths[1])
 
-    items = list(target_col.get_all_items())
+    items = list(target_col.get_items(recursive=True))
     assert len(items) == 2
 
     for item in items:

--- a/tests/cli/commands/test_migrate.py
+++ b/tests/cli/commands/test_migrate.py
@@ -36,7 +36,7 @@ def test_migrate_with_save_no_recursive(tmp_planet_disaster_path: str):
     path = tmp_planet_disaster_path
     root = pystac.Collection.from_file(path)
     child_path = next(root.get_children()).get_self_href()
-    item_path = next(root.get_all_items()).get_self_href()
+    item_path = next(root.get_items(recursive=True)).get_self_href()
 
     with open(path) as f:
         root_before = f.readlines()
@@ -69,7 +69,7 @@ def test_migrate_with_save_and_recursive(tmp_planet_disaster_path: str):
     path = tmp_planet_disaster_path
     root = pystac.Collection.from_file(path)
     child_path = next(root.get_children()).get_self_href()
-    item_path = next(root.get_all_items()).get_self_href()
+    item_path = next(root.get_items(recursive=True)).get_self_href()
 
     with open(path) as f:
         root_before = f.readlines()
@@ -102,7 +102,7 @@ def test_migrate_show_diff(tmp_planet_disaster_path: str):
     path = tmp_planet_disaster_path
     root = pystac.Collection.from_file(path)
     child_path = next(root.get_children()).get_self_href()
-    item_path = next(root.get_all_items()).get_self_href()
+    item_path = next(root.get_items(recursive=True)).get_self_href()
 
     runner = CliRunner()
     result = runner.invoke(cli, ["migrate", path, "--show-diff"])
@@ -118,7 +118,7 @@ def test_migrate_show_diff_and_recursive(tmp_planet_disaster_path: str):
     path = tmp_planet_disaster_path
     root = pystac.Collection.from_file(path)
     child_path = next(root.get_children()).get_self_href()
-    item_path = next(root.get_all_items()).get_self_href()
+    item_path = next(root.get_items(recursive=True)).get_self_href()
 
     runner = CliRunner()
     result = runner.invoke(cli, ["migrate", path, "--show-diff", "--recursive"])
@@ -153,7 +153,7 @@ def test_migrate_hide_diff(tmp_planet_disaster_path: str):
 def test_migrate_recursive_invalid_for_items(tmp_planet_disaster_path: str):
     path = tmp_planet_disaster_path
     root = pystac.Collection.from_file(path)
-    item_path = next(root.get_all_items()).get_self_href()
+    item_path = next(root.get_items(recursive=True)).get_self_href()
 
     runner = CliRunner()
     result = runner.invoke(cli, ["migrate", item_path, "-r"])


### PR DESCRIPTION
**Description:**
~Disallow warnings in tests, which encourages (nay, forces) us to stop using deprecated items.~ There are some warnings from **stac-check** that I'm having trouble filtering out, so for now I'm dropping the "upgrade to error" bit and just fixing the deprecated pystac function usages.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [ ] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
