### PR TITLE
Pass auto_mkdir in fsspec write

### DIFF
--- a/src/stactools/core/io/__init__.py
+++ b/src/stactools/core/io/__init__.py
@@ -109,7 +109,7 @@ class FsspecStacIO(StacIO):
             txt (str): The text to write.
             **kwargs: Additional keyword arguments to be passed to fsspec.open.
         """
-        with fsspec.open(href, "w", **kwargs) as destination:
+        with fsspec.open(href, "w", auto_mkdir=True, **kwargs) as destination:
             destination.write(txt)
 
 


### PR DESCRIPTION
**Related Issue(s):**
- We were implicitly relying on behavior fixed by https://github.com/fsspec/filesystem_spec/pull/1358.

**Description:**

No changelog needed. Discovered due to CI breaks.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [ ] Documentation has been updated to reflect changes, if applicable.
- [ ] Changes are added to the [CHANGELOG](../CHANGELOG.md).
