### PR TITLE
Make stac-validator and stac-check optional

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install with extra_requires
-        run: pip install .[s3,dev]
+        run: pip install .[s3,validate,dev]
       - name: Test
         run: ./scripts/test
   minimum-versions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Make computation of statistics and histogram optional for `core.add_raster.add_raster_to_item` ([#467](https://github.com/stac-utils/stactools/pull/467))
+- Make **stac-validator** and **stac-check** optional dependencies ([#468](https://github.com/stac-utils/stactools/pull/468))
 
 ## [0.5.2] - 2023-09-20
 

--- a/README.md
+++ b/README.md
@@ -48,14 +48,16 @@ If your system GDAL is older than version 3.1, consider using [Docker](#using-do
 
 ### Optional dependencies
 
-`stactools` includes one optional dependency:
+`stactools` includes two optional dependency:
 
 - `s3`: Enables s3 hrefs via `fsspec` and `s3fs`
+- `validate`: Enables `stac validate` and `stac lint`
 
-To install the single optional dependency:
+To install optional dependencies:
 
 ```sh
-pip install stactools[s3]
+pip install 'stactools[s3]'
+pip install 'stactools[validate]'
 ```
 
 ### Docker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,6 @@ dependencies = [
     "pystac[validation]>=1.8.2",
     "rasterio>=1.3.2",
     "shapely>=2.0.1",
-    "stac-check>=1.3.2",
-    "stac-validator>=3.1.0",
 ]
 dynamic = ["version"]
 
@@ -73,6 +71,7 @@ docs = [
     "sphinxcontrib-fulltoc~=1.2",
 ]
 s3 = ["s3fs>=2021.7"]
+validate = ["stac-check>=1.3.2", "stac-validator>=3.1.0"]
 
 [build-system]
 requires = ["setuptools", "wheel"]

--- a/src/stactools/cli/__init__.py
+++ b/src/stactools/cli/__init__.py
@@ -2,6 +2,21 @@
 
 import stactools.core
 
+try:
+    import stac_validator as _
+except ImportError:
+    HAS_STAC_VALIDATOR = False
+else:
+    HAS_STAC_VALIDATOR = True
+
+try:
+    import stac_check as _
+except ImportError:
+    HAS_STAC_CHECK = False
+else:
+    HAS_STAC_CHECK = True
+
+
 stactools.core.use_fsspec()
 
 
@@ -16,13 +31,11 @@ def register_plugin(registry: "Registry") -> None:
         create,
         info,
         layout,
-        lint,
         merge,
         migrate,
         summary,
         update_extent,
         update_geometry,
-        validate,
         version,
     )
 
@@ -35,14 +48,22 @@ def register_plugin(registry: "Registry") -> None:
     registry.register_subcommand(info.create_info_command)
     registry.register_subcommand(info.create_describe_command)
     registry.register_subcommand(layout.create_layout_command)
-    registry.register_subcommand(lint.create_lint_command)
     registry.register_subcommand(merge.create_merge_command)
     registry.register_subcommand(migrate.create_migrate_command)
     registry.register_subcommand(summary.create_summary_command)
-    registry.register_subcommand(validate.create_validate_command)
     registry.register_subcommand(version.create_version_command)
     registry.register_subcommand(update_extent.create_update_extent_command)
     registry.register_subcommand(update_geometry.create_update_geometry_command)
+
+    if HAS_STAC_VALIDATOR:
+        from stactools.cli.commands import validate
+
+        registry.register_subcommand(validate.create_validate_command)
+
+    if HAS_STAC_CHECK:
+        from stactools.cli.commands import lint
+
+        registry.register_subcommand(lint.create_lint_command)
 
 
 from stactools.cli.registry import Registry

--- a/tests/cli/commands/test_lint.py
+++ b/tests/cli/commands/test_lint.py
@@ -1,7 +1,10 @@
+import pytest
 from click.testing import CliRunner
 from stactools.cli.cli import cli
 
 from tests import test_data
+
+pytest.importorskip("stac_check")
 
 
 def test_valid_item() -> None:

--- a/tests/cli/commands/test_validate.py
+++ b/tests/cli/commands/test_validate.py
@@ -4,6 +4,8 @@ from stactools.cli.cli import cli
 
 from tests import test_data
 
+pytest.importorskip("stac_validator")
+
 
 def test_valid_item() -> None:
     path = test_data.get_path(


### PR DESCRIPTION
**Description:**
They have some unnecessary required dependencies that pollute downstreams. cc @pjhartzell @jkeifer 

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
