### PR TITLE
Remove quiet argument to `stac validate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
 - Make computation of statistics and histogram optional for `core.add_raster.add_raster_to_item` ([#467](https://github.com/stac-utils/stactools/pull/467))
 - Make **stac-validator** and **stac-check** optional dependencies ([#468](https://github.com/stac-utils/stactools/pull/468))
+
+### Removed
+
+- `--quiet` argument to `stac validate` ([#471](https://github.com/stac-utils/stactools/pull/471))
 
 ## [0.5.2] - 2023-09-20
 

--- a/src/stactools/cli/commands/validate.py
+++ b/src/stactools/cli/commands/validate.py
@@ -22,9 +22,6 @@ def create_validate_command(cli: click.Group) -> click.Command:
     )
     @click.option("-v", "--verbose", is_flag=True, help="Enables verbose output.")
     @click.option(
-        "--quiet/--no-quiet", help="Do not print output to console.", default=False
-    )
-    @click.option(
         "--log-file",
         help="Save output to file (local filepath).",
     )
@@ -34,7 +31,6 @@ def create_validate_command(cli: click.Group) -> click.Command:
         validate_links: bool,
         validate_assets: bool,
         verbose: bool,
-        quiet: bool,
         log_file: Optional[str],
     ) -> None:
         """Validates a STAC object.
@@ -52,12 +48,10 @@ def create_validate_command(cli: click.Group) -> click.Command:
             links=validate_links,
             assets=validate_assets,
             verbose=verbose,
-            no_output=quiet,
             log=log_file or "",
         )
         is_valid = validate.run()
-        if not quiet:
-            click.echo(json.dumps(validate.message, indent=4))
+        click.echo(json.dumps(validate.message, indent=4))
         if is_valid:
             sys.exit(0)
         else:


### PR DESCRIPTION
**Description:**
`no_output` was removed in
https://github.com/stac-utils/stac-validator/commit/296b3ae5088ab2b92f3eaf5e4dfec1d57e50ec5d. Doesn't constitute a breaking change b/c CLI arguments aren't part of our "public API".

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
